### PR TITLE
Add VK captcha support via WebView popup

### DIFF
--- a/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Native interface for TURN proxy management.
@@ -88,6 +89,50 @@ public final class TurnBackend {
             return false;
         }
     }
+
+    // --- Captcha support ---
+
+    /**
+     * Callback that receives a captcha redirect URI and must return the success_token.
+     * The function is called from a background (Go) thread. It should block until
+     * the captcha is solved or return empty string on failure/timeout.
+     */
+    private static volatile Function<String, String> captchaHandler;
+
+    /**
+     * Sets the captcha handler. Call this from Application.onCreate() or similar.
+     * @param handler Function that takes redirect_uri and returns success_token
+     */
+    public static void setCaptchaHandler(@Nullable Function<String, String> handler) {
+        captchaHandler = handler;
+        Log.d(TAG, "Captcha handler " + (handler != null ? "registered" : "cleared"));
+    }
+
+    /**
+     * Called from JNI (Go thread) when VK API requires captcha.
+     * Blocks the calling thread until captcha is solved.
+     * @param redirectUri The VK captcha page URL to show in WebView
+     * @return success_token string, or empty string on failure
+     */
+    @SuppressWarnings("unused") // Called from native code
+    public static String onCaptchaRequired(String redirectUri) {
+        Log.d(TAG, "onCaptchaRequired called with URI length=" + (redirectUri != null ? redirectUri.length() : 0));
+        Function<String, String> handler = captchaHandler;
+        if (handler == null) {
+            Log.e(TAG, "No captcha handler registered!");
+            return "";
+        }
+        try {
+            String result = handler.apply(redirectUri);
+            Log.d(TAG, "Captcha handler returned: " + (result != null && !result.isEmpty() ? "token" : "empty"));
+            return result != null ? result : "";
+        } catch (Exception e) {
+            Log.e(TAG, "Captcha handler threw exception", e);
+            return "";
+        }
+    }
+
+    // --- End captcha support ---
 
     public static native void wgSetVpnService(@Nullable VpnService service);
 

--- a/tunnel/tools/libwg-go/jni.c
+++ b/tunnel/tools/libwg-go/jni.c
@@ -20,6 +20,9 @@ extern int wgTurnProxyStart(const char *peer_addr, const char *vklink, int n, in
 extern void wgTurnProxyStop();
 extern void wgNotifyNetworkChange();
 
+static jclass turn_backend_class_global = NULL;
+static jmethodID on_captcha_required_method = NULL;
+
 static JavaVM *java_vm;
 static jobject vpn_service_global;
 static jmethodID protect_method;
@@ -104,6 +107,16 @@ JNIEXPORT void JNICALL Java_com_wireguard_android_backend_TurnBackend_wgSetVpnSe
 		jclass vpn_service_class = (*env)->GetObjectClass(env, vpn_service_global);
 		protect_method = (*env)->GetMethodID(env, vpn_service_class, "protect", "(I)Z");
 		get_system_service_method = (*env)->GetMethodID(env, vpn_service_class, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+
+		// Cache TurnBackend class and captcha method
+		if (!turn_backend_class_global) {
+			jclass tb_class = (*env)->FindClass(env, "com/wireguard/android/backend/TurnBackend");
+			if (tb_class) {
+				turn_backend_class_global = (*env)->NewGlobalRef(env, tb_class);
+				on_captcha_required_method = (*env)->GetStaticMethodID(env, turn_backend_class_global, "onCaptchaRequired", "(Ljava/lang/String;)Ljava/lang/String;");
+				(*env)->DeleteLocalRef(env, tb_class);
+			}
+		}
 		
 		jclass cm_class = (*env)->FindClass(env, "android/net/ConnectivityManager");
 		connectivity_manager_class_global = (*env)->NewGlobalRef(env, cm_class);
@@ -264,4 +277,55 @@ JNIEXPORT void JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 {
 	update_current_network(env, 0);
 	wgTurnProxyStop();
+}
+
+// Called from Go to request captcha solving from Android UI.
+// Blocks until the user solves the captcha or timeout.
+// Returns a malloc'd string that the caller (Go) must free.
+const char* requestCaptcha(const char* redirect_uri)
+{
+	JNIEnv *env;
+	int attached = 0;
+	const char* result = NULL;
+
+	if (!java_vm || !turn_backend_class_global || !on_captcha_required_method) {
+		__android_log_print(ANDROID_LOG_ERROR, "WireGuard/JNI",
+			"requestCaptcha: JNI not initialized (vm=%p, class=%p, method=%p)",
+			java_vm, turn_backend_class_global, on_captcha_required_method);
+		return NULL;
+	}
+
+	if ((*java_vm)->GetEnv(java_vm, (void **)&env, JNI_VERSION_1_6) == JNI_EDETACHED) {
+		if ((*java_vm)->AttachCurrentThread(java_vm, &env, NULL) != 0) {
+			__android_log_print(ANDROID_LOG_ERROR, "WireGuard/JNI",
+				"requestCaptcha: AttachCurrentThread failed");
+			return NULL;
+		}
+		attached = 1;
+	}
+
+	jstring j_uri = (*env)->NewStringUTF(env, redirect_uri);
+	jstring j_result = (jstring)(*env)->CallStaticObjectMethod(env, turn_backend_class_global,
+		on_captcha_required_method, j_uri);
+	(*env)->DeleteLocalRef(env, j_uri);
+
+	if ((*env)->ExceptionCheck(env)) {
+		__android_log_print(ANDROID_LOG_ERROR, "WireGuard/JNI",
+			"requestCaptcha: exception occurred");
+		(*env)->ExceptionClear(env);
+	} else if (j_result != NULL) {
+		const char* str = (*env)->GetStringUTFChars(env, j_result, NULL);
+		if (str && strlen(str) > 0) {
+			result = strdup(str);
+		}
+		(*env)->ReleaseStringUTFChars(env, j_result, str);
+		(*env)->DeleteLocalRef(env, j_result);
+	}
+
+	if (attached)
+		(*java_vm)->DetachCurrentThread(java_vm);
+
+	__android_log_print(ANDROID_LOG_INFO, "WireGuard/JNI",
+		"requestCaptcha: returning %s", result ? "token" : "NULL");
+	return result;
 }

--- a/tunnel/tools/libwg-go/turn-credentials.go
+++ b/tunnel/tools/libwg-go/turn-credentials.go
@@ -5,6 +5,12 @@
 
 package main
 
+/*
+#include <stdlib.h>
+extern const char* requestCaptcha(const char* redirect_uri);
+*/
+import "C"
+
 import (
 	"bytes"
 	"context"
@@ -19,6 +25,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/google/uuid"
 )
@@ -409,14 +416,24 @@ func getTokenChain(ctx context.Context, link string, streamID int, creds VKCrede
 	data = fmt.Sprintf("vk_join_link=https://vk.ru/call/join/%s&name=123&access_token=%s", url.QueryEscape(link), token3)
 	urlAddr := fmt.Sprintf("https://api.vk.ru/method/calls.getAnonymousToken?v=5.274&client_id=%s", creds.ClientID)
 	resp, err = doRequest(data, urlAddr)
+	// Check for captcha error (error_code 14) before giving up
 	if err != nil {
-		turnLog("[STREAM %d] [VK Auth] Token 4 request failed: %v", streamID, err)
-		return "", "", "", err
-	}
-	// Check for VK API error in response
-	if errMsg, ok := resp["error"].(map[string]interface{}); ok {
-		turnLog("[STREAM %d] [VK Auth] Token 4 VK API error: %v", streamID, errMsg)
-		return "", "", "", fmt.Errorf("VK API error (token4): %v", errMsg)
+		if errMsg, ok := resp["error"].(map[string]interface{}); ok {
+			errorCode, _ := errMsg["error_code"].(float64)
+			if int(errorCode) == 14 {
+				turnLog("[STREAM %d] [VK Auth] Captcha required! Requesting user input...", streamID)
+				resp, err = handleCaptchaError(errMsg, streamID, link, token3, creds, doRequest)
+				if err != nil {
+					return "", "", "", fmt.Errorf("captcha handling failed: %w", err)
+				}
+			} else {
+				turnLog("[STREAM %d] [VK Auth] Token 4 VK API error: %v", streamID, errMsg)
+				return "", "", "", fmt.Errorf("VK API error (token4): %v", errMsg)
+			}
+		} else {
+			turnLog("[STREAM %d] [VK Auth] Token 4 request failed: %v", streamID, err)
+			return "", "", "", err
+		}
 	}
 	responseRaw, ok := resp["response"]
 	if !ok {
@@ -544,4 +561,84 @@ func getTokenChain(ctx context.Context, link string, streamID int, creds VKCrede
 		return "", "", "", fmt.Errorf("credential not found in turn_server: %v", ts)
 	}
 	return username, credential, address, nil
+}
+
+// handleCaptchaError handles VK captcha challenge (error_code 14).
+// It opens the captcha page via Android WebView and retries the request with the result.
+func handleCaptchaError(errMsg map[string]interface{}, streamID int, link string, token3 string, creds VKCredentials, doRequest func(string, string) (map[string]interface{}, error)) (map[string]interface{}, error) {
+	redirectURI, _ := errMsg["redirect_uri"].(string)
+
+	// captcha_sid can be string or number in JSON
+	var captchaSid string
+	switch v := errMsg["captcha_sid"].(type) {
+	case string:
+		captchaSid = v
+	case float64:
+		captchaSid = fmt.Sprintf("%.0f", v)
+	}
+
+	captchaTs, _ := errMsg["captcha_ts"].(float64)
+	captchaAttempt, _ := errMsg["captcha_attempt"].(float64)
+	if captchaAttempt == 0 {
+		captchaAttempt = 1
+	}
+
+	if redirectURI == "" {
+		return nil, fmt.Errorf("captcha error but no redirect_uri provided")
+	}
+
+	turnLog("[STREAM %d] [VK Auth] Captcha redirect_uri: %s", streamID, redirectURI)
+	turnLog("[STREAM %d] [VK Auth] Captcha SID: %s", streamID, captchaSid)
+
+	// Call Android to show captcha WebView and get success_token
+	successToken := solveCaptcha(redirectURI)
+	if successToken == "" {
+		return nil, fmt.Errorf("captcha was not solved (empty success_token)")
+	}
+
+	turnLog("[STREAM %d] [VK Auth] Captcha solved, retrying with success_token", streamID)
+
+	// Retry calls.getAnonymousToken with captcha parameters
+	data := fmt.Sprintf(
+		"vk_join_link=https://vk.ru/call/join/%s&name=123&captcha_key=&captcha_sid=%s&is_sound_captcha=0&success_token=%s&captcha_ts=%.3f&captcha_attempt=%d&access_token=%s",
+		url.QueryEscape(link),
+		captchaSid,
+		url.QueryEscape(successToken),
+		captchaTs,
+		int(captchaAttempt),
+		token3,
+	)
+	urlAddr := fmt.Sprintf("https://api.vk.ru/method/calls.getAnonymousToken?v=5.274&client_id=%s", creds.ClientID)
+
+	resp, err := doRequest(data, urlAddr)
+	if err != nil {
+		return nil, fmt.Errorf("token4 retry after captcha failed: %w", err)
+	}
+
+	// Check if the retry also returned an error
+	if errMsg2, ok := resp["error"].(map[string]interface{}); ok {
+		return nil, fmt.Errorf("token4 retry after captcha returned error: %v", errMsg2)
+	}
+
+	return resp, nil
+}
+
+// captchaMu ensures only one captcha dialog is shown at a time
+var captchaMu sync.Mutex
+
+// solveCaptcha calls Android via JNI to show captcha WebView and waits for the result.
+func solveCaptcha(redirectURI string) string {
+	captchaMu.Lock()
+	defer captchaMu.Unlock()
+
+	cURI := C.CString(redirectURI)
+	defer C.free(unsafe.Pointer(cURI))
+
+	result := C.requestCaptcha(cURI)
+	if result == nil {
+		return ""
+	}
+	goResult := C.GoString((*C.char)(unsafe.Pointer(result)))
+	C.free(unsafe.Pointer(result))
+	return goResult
 }

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -95,6 +95,12 @@
             tools:replace="screenOrientation" />
 
         <activity
+            android:name=".activity.CaptchaActivity"
+            android:exported="false"
+            android:theme="@style/AppTheme"
+            android:label="@string/captcha_title" />
+
+        <activity
             android:name=".activity.LogViewerActivity"
             android:exported="false"
             android:label="@string/log_viewer_title">

--- a/ui/src/main/java/com/wireguard/android/Application.kt
+++ b/ui/src/main/java/com/wireguard/android/Application.kt
@@ -17,8 +17,10 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.google.android.material.color.DynamicColors
+import com.wireguard.android.activity.CaptchaActivity
 import com.wireguard.android.backend.Backend
 import com.wireguard.android.backend.GoBackend
+import com.wireguard.android.backend.TurnBackend
 import com.wireguard.android.backend.WgQuickBackend
 import com.wireguard.android.configStore.FileConfigStore
 import com.wireguard.android.model.TunnelManager
@@ -116,6 +118,12 @@ class Application : android.app.Application() {
         // Load wg-go library BEFORE creating TurnProxyManager to avoid UnsatisfiedLinkError
         com.wireguard.android.util.SharedLibraryLoader.loadSharedLibrary(applicationContext, "wg-go")
         turnProxyManager = TurnProxyManager(applicationContext)
+
+        // Register captcha handler: when Go needs captcha, launch CaptchaActivity
+        TurnBackend.setCaptchaHandler { redirectUri ->
+            CaptchaActivity.solveCaptcha(applicationContext, redirectUri)
+        }
+
         tunnelManager.onCreate()
         coroutineScope.launch(Dispatchers.IO) {
             try {

--- a/ui/src/main/java/com/wireguard/android/activity/CaptchaActivity.kt
+++ b/ui/src/main/java/com/wireguard/android/activity/CaptchaActivity.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2026.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.wireguard.android.activity
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.os.Bundle
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Transparent-themed activity that shows a WebView dialog for VK captcha solving.
+ * The WebView loads the VK "not_robot_captcha" page and intercepts the success_token
+ * via JavaScript injection.
+ */
+class CaptchaActivity : AppCompatActivity() {
+
+    private var previousNetwork: Network? = null
+    private var didBindNetwork = false
+
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val redirectUri = intent.getStringExtra(EXTRA_REDIRECT_URI)
+        if (redirectUri.isNullOrEmpty()) {
+            Log.e(TAG, "No redirect URI provided")
+            deliverResult("")
+            finish()
+            return
+        }
+
+        // Bypass VPN: bind process to a physical (non-VPN) network
+        // so the WebView can actually reach id.vk.ru
+        bindToPhysicalNetwork()
+
+        Log.d(TAG, "Loading captcha page...")
+
+        val webView = WebView(this).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            settings.userAgentString = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Mobile Safari/537.36"
+
+            addJavascriptInterface(CaptchaBridge(), "AndroidCaptcha")
+
+            webChromeClient = WebChromeClient()
+
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    // Inject JS to intercept the captchaNotRobot.check response
+                    view?.evaluateJavascript(INTERCEPT_SCRIPT, null)
+                }
+
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): Boolean {
+                    // Keep all navigation inside the WebView
+                    return false
+                }
+            }
+        }
+
+        setContentView(webView)
+        webView.loadUrl(redirectUri)
+    }
+
+    private fun deliverResult(token: String) {
+        pendingResult?.complete(token)
+    }
+
+    private inner class CaptchaBridge {
+        @JavascriptInterface
+        fun onResult(successToken: String) {
+            Log.d(TAG, "Captcha solved, got success_token (length=${successToken.length})")
+            runOnUiThread {
+                deliverResult(successToken)
+                finish()
+            }
+        }
+    }
+
+    /**
+     * Binds the process to a physical (non-VPN) network so the WebView
+     * can resolve DNS and load the captcha page even when VPN kill-switch is active.
+     */
+    private fun bindToPhysicalNetwork() {
+        try {
+            val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            previousNetwork = cm.boundNetworkForProcess
+
+            val networks = cm.allNetworks
+            for (network in networks) {
+                val caps = cm.getNetworkCapabilities(network) ?: continue
+                if (caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) continue
+                if (!caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) continue
+
+                cm.bindProcessToNetwork(network)
+                didBindNetwork = true
+                val type = when {
+                    caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "WiFi"
+                    caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "Cellular"
+                    else -> "Other"
+                }
+                Log.d(TAG, "Bound process to physical network: $network ($type)")
+                return
+            }
+            Log.w(TAG, "No physical network found to bind to!")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to bind to physical network", e)
+        }
+    }
+
+    /**
+     * Restores the previous network binding after captcha is done.
+     */
+    private fun restoreNetworkBinding() {
+        if (!didBindNetwork) return
+        try {
+            val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            cm.bindProcessToNetwork(previousNetwork)
+            Log.d(TAG, "Restored previous network binding")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to restore network binding", e)
+        }
+    }
+
+    override fun onDestroy() {
+        restoreNetworkBinding()
+        super.onDestroy()
+        // If activity destroyed without result (back button etc.), deliver empty
+        deliverResult("")
+    }
+
+    companion object {
+        private const val TAG = "WireGuard/CaptchaActivity"
+        private const val EXTRA_REDIRECT_URI = "redirect_uri"
+        private const val CAPTCHA_TIMEOUT_SECONDS = 120L
+
+        @Volatile
+        private var pendingResult: CompletableFuture<String>? = null
+
+        /**
+         * JavaScript that intercepts XHR/fetch calls to captchaNotRobot.check
+         * and extracts the success_token from the response.
+         * Also intercepts postMessage in case the page sends the result that way.
+         */
+        private val INTERCEPT_SCRIPT = """
+            (function() {
+                // Intercept XMLHttpRequest
+                var origOpen = XMLHttpRequest.prototype.open;
+                var origSend = XMLHttpRequest.prototype.send;
+                XMLHttpRequest.prototype.open = function() {
+                    this._captchaUrl = arguments[1];
+                    return origOpen.apply(this, arguments);
+                };
+                XMLHttpRequest.prototype.send = function() {
+                    var xhr = this;
+                    if (xhr._captchaUrl && xhr._captchaUrl.indexOf('captchaNotRobot.check') !== -1) {
+                        xhr.addEventListener('load', function() {
+                            try {
+                                var data = JSON.parse(xhr.responseText);
+                                if (data.response && data.response.success_token) {
+                                    AndroidCaptcha.onResult(data.response.success_token);
+                                }
+                            } catch(e) {}
+                        });
+                    }
+                    return origSend.apply(this, arguments);
+                };
+
+                // Intercept fetch
+                var origFetch = window.fetch;
+                if (origFetch) {
+                    window.fetch = function() {
+                        var url = arguments[0];
+                        if (typeof url === 'object' && url.url) url = url.url;
+                        var p = origFetch.apply(this, arguments);
+                        if (typeof url === 'string' && url.indexOf('captchaNotRobot.check') !== -1) {
+                            p.then(function(response) {
+                                return response.clone().json();
+                            }).then(function(data) {
+                                if (data.response && data.response.success_token) {
+                                    AndroidCaptcha.onResult(data.response.success_token);
+                                }
+                            }).catch(function(e) {});
+                        }
+                        return p;
+                    };
+                }
+
+                // Intercept postMessage as backup
+                window.addEventListener('message', function(e) {
+                    try {
+                        var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                        if (data && data.success_token) {
+                            AndroidCaptcha.onResult(data.success_token);
+                        } else if (data && data.response && data.response.success_token) {
+                            AndroidCaptcha.onResult(data.response.success_token);
+                        }
+                    } catch(ex) {}
+                });
+            })();
+        """.trimIndent()
+
+        /**
+         * Launches the captcha activity and blocks until result is available.
+         * Called from a background thread (Go thread via JNI).
+         * @param context Application context
+         * @param redirectUri VK captcha redirect URI
+         * @return success_token or empty string
+         */
+        fun solveCaptcha(context: Context, redirectUri: String): String {
+            Log.d(TAG, "solveCaptcha called, launching activity...")
+
+            val future = CompletableFuture<String>()
+            pendingResult = future
+
+            val intent = Intent(context, CaptchaActivity::class.java).apply {
+                putExtra(EXTRA_REDIRECT_URI, redirectUri)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+
+            return try {
+                val result = future.get(CAPTCHA_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                Log.d(TAG, "solveCaptcha result: ${if (result.isNotEmpty()) "token" else "empty"}")
+                result
+            } catch (e: Exception) {
+                Log.e(TAG, "solveCaptcha failed", e)
+                ""
+            } finally {
+                pendingResult = null
+            }
+        }
+    }
+}

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -277,4 +277,5 @@
     <string name="turn_port">Turn port</string>
     <string name="turn_port_hint">(auto)</string>
     <string name="turn_no_dtls">No DTLS (not recommended)</string>
+    <string name="captcha_title">VK Captcha</string>
 </resources>


### PR DESCRIPTION
When VK API returns error_code:14 (Captcha needed) during token acquisition, the app now shows a WebView activity with the VK not_robot_captcha page. The WebView is bound to the physical network (bypassing VPN kill-switch) so it can actually load the page.

JavaScript injection intercepts the captchaNotRobot.check response to capture the success_token, which is then passed back through JNI to Go to retry the API call.