### PR TITLE
Изменён порядок запуска: сначала TURN, затем WireGuard

### DIFF
--- a/tunnel/src/main/java/com/wireguard/android/backend/GoBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/GoBackend.java
@@ -205,6 +205,51 @@ public final class GoBackend implements Backend {
     }
 
     /**
+     * Starts and registers {@link VpnService} without creating the WireGuard tunnel yet.
+     *
+     * TURN uses this service for {@link android.net.VpnService#protect(int)} before the
+     * userspace tunnel is brought up.
+     */
+    public VpnService ensureVpnServiceReady() throws Exception {
+        if (VpnService.prepare(context) != null)
+            throw new BackendException(Reason.VPN_NOT_AUTHORIZED);
+
+        if (!vpnService.isDone()) {
+            Log.d(TAG, "Requesting to start VpnService");
+            context.startService(new Intent(context, VpnService.class));
+        }
+
+        final VpnService service;
+        try {
+            service = vpnService.get(2, TimeUnit.SECONDS);
+        } catch (final TimeoutException e) {
+            final Exception be = new BackendException(Reason.UNABLE_TO_START_VPN);
+            be.initCause(e);
+            throw be;
+        }
+        service.setOwner(this);
+        return service;
+    }
+
+    /**
+     * Stops {@link VpnService} when it was only prepared for TURN startup and no tunnel was
+     * successfully activated.
+     */
+    public void stopVpnServiceIfIdle() {
+        if (currentTunnelHandle != -1)
+            return;
+        try {
+            vpnService.get(0, TimeUnit.NANOSECONDS).stopSelf();
+        } catch (final TimeoutException ignored) {
+        } catch (final ExecutionException e) {
+            Log.w(TAG, "Unable to stop idle VpnService", e);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.w(TAG, "Interrupted while stopping idle VpnService", e);
+        }
+    }
+
+    /**
      * Change the state of a given {@link Tunnel}, optionally applying a given {@link Config}.
      *
      * @param tunnel The tunnel to control the state of.
@@ -247,24 +292,7 @@ public final class GoBackend implements Backend {
         if (state == State.UP) {
             if (config == null)
                 throw new BackendException(Reason.TUNNEL_MISSING_CONFIG);
-
-            if (VpnService.prepare(context) != null)
-                throw new BackendException(Reason.VPN_NOT_AUTHORIZED);
-
-            final VpnService service;
-            if (!vpnService.isDone()) {
-                Log.d(TAG, "Requesting to start VpnService");
-                context.startService(new Intent(context, VpnService.class));
-            }
-
-            try {
-                service = vpnService.get(2, TimeUnit.SECONDS);
-            } catch (final TimeoutException e) {
-                final Exception be = new BackendException(Reason.UNABLE_TO_START_VPN);
-                be.initCause(e);
-                throw be;
-            }
-            service.setOwner(this);
+            final VpnService service = ensureVpnServiceReady();
 
             if (currentTunnelHandle != -1) {
                 Log.w(TAG, "Tunnel already up");
@@ -350,11 +378,6 @@ public final class GoBackend implements Backend {
             // Protect WireGuard sockets
             service.protect(wgGetSocketV4(currentTunnelHandle));
             service.protect(wgGetSocketV6(currentTunnelHandle));
-
-            // NEW: Start TURN proxy AFTER tunnel is established
-            // This ensures VpnService.protect() will work for TURN sockets
-            // TurnProxyManager will be called from UI module via callback
-            Log.d(TAG, "Tunnel established, TURN proxy should be started now");
         } else {
             if (currentTunnelHandle == -1) {
                 Log.w(TAG, "Tunnel already down");

--- a/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
@@ -18,6 +18,10 @@ import java.util.function.Function;
  * Native interface for TURN proxy management.
  */
 public final class TurnBackend {
+    public static final int WG_TURN_PROXY_SUCCESS = 0;
+    public static final int WG_TURN_PROXY_ERROR_GENERIC = -1;
+    public static final int WG_TURN_PROXY_ERROR_VK_LINK_EXPIRED = -9000;
+
     private static final AtomicReference<CompletableFuture<VpnService>> vpnServiceFutureRef = new AtomicReference<>(new CompletableFuture<>());
 
     // Latch for synchronization: signals that JNI is registered and ready to protect sockets
@@ -138,6 +142,23 @@ public final class TurnBackend {
 
     public static native void wgSetVpnService(@Nullable VpnService service);
 
+    /**
+     * Starts the native TURN proxy and returns a detailed startup status code.
+     *
+     * @param peerAddr Peer address
+     * @param vklink VK call link
+     * @param mode TURN mode
+     * @param n Number of streams
+     * @param useUdp Whether UDP is enabled
+     * @param listenAddr Local listen address
+     * @param turnIp TURN server IP
+     * @param turnPort TURN server port
+     * @param peerType Peer type
+     * @param streamsPerCred Number of streams sharing one TURN credential cache
+     * @param watchdogTimeout DTLS watchdog timeout in seconds, 0 to disable
+     * @param networkHandle Android network handle for socket binding
+     * @return 0 on success, -1 on generic failure, -9000 when VK reports that the call link expired
+     */
     public static native int wgTurnProxyStart(
             String peerAddr,
             String vklink,

--- a/ui/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/ui/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -18,11 +18,13 @@ import com.wireguard.android.Application.Companion.getTunnelManager
 import com.wireguard.android.Application.Companion.getTurnProxyManager
 import com.wireguard.android.BR
 import com.wireguard.android.R
+import com.wireguard.android.backend.GoBackend
 import com.wireguard.android.backend.Statistics
 import com.wireguard.android.backend.Tunnel
 import com.wireguard.android.configStore.ConfigStore
 import com.wireguard.android.databinding.ObservableSortedKeyedArrayList
 import com.wireguard.android.turn.TurnConfigProcessor
+import com.wireguard.android.turn.TurnProxyManager
 import com.wireguard.android.turn.TurnSettings
 import com.wireguard.android.turn.TurnSettingsStore
 import com.wireguard.android.util.ErrorMessages
@@ -274,19 +276,30 @@ class TunnelManager(
         var newState = tunnel.state
         var throwable: Throwable? = null
         try {
+            val backend = getBackend()
             var configToUse = tunnel.getConfigAsync()
             val turn = tunnel.turnSettings
             val turnEnabled = turn != null && turn.enabled
             
-            // Determine if TURN should be started after tunnel is established
+            // Determine if TURN should be started before WireGuard activation.
             // This happens when explicitly requesting UP, or TOGGLE from DOWN state
             val shouldStartTurn = state == Tunnel.State.UP || (state == Tunnel.State.TOGGLE && tunnel.state == Tunnel.State.DOWN)
             
             // Stop TURN when tunnel goes DOWN
             val shouldStopTurn = state == Tunnel.State.DOWN || (state == Tunnel.State.TOGGLE && tunnel.state == Tunnel.State.UP)
 
+            suspend fun cleanupFailedTurnStartup(goBackend: GoBackend) {
+                withContext(Dispatchers.IO) {
+                    getTurnProxyManager().stopForTunnel(tunnel.name)
+                    goBackend.stopVpnServiceIfIdle()
+                }
+            }
+
             if (turnEnabled) {
                 if (shouldStartTurn) {
+                    tunnelMap
+                        .filter { it !== tunnel && it.state == Tunnel.State.UP }
+                        .forEach { activeTunnel -> setTunnelState(activeTunnel, Tunnel.State.DOWN) }
                     configToUse = TurnConfigProcessor.modifyConfigForActiveTurn(configToUse, turn)
                 } else if (shouldStopTurn) {
                     withContext(Dispatchers.IO) {
@@ -295,22 +308,32 @@ class TunnelManager(
                 }
             }
 
-            newState = withContext(Dispatchers.IO) { getBackend().setState(tunnel, state, configToUse) }
+            if (shouldStartTurn && turnEnabled) {
+                val goBackend = backend as? GoBackend
+                    ?: throw IllegalStateException("TURN startup requires the Go backend")
 
-            // NEW: Start TURN AFTER tunnel is established
-            // This ensures VpnService.protect() will work for TURN sockets
-            if (shouldStartTurn && newState == Tunnel.State.UP) {
-                if (turnEnabled) {
-                    Log.d(TAG, "Tunnel established, starting TURN proxy...")
-                    val turnStarted = withContext(Dispatchers.IO) {
-                        getTurnProxyManager().onTunnelEstablished(tunnel.name, turn)
+                withContext(Dispatchers.IO) { goBackend.ensureVpnServiceReady() }
+
+                when (val turnResult = withContext(Dispatchers.IO) {
+                    getTurnProxyManager().onTunnelEstablished(tunnel.name, turn)
+                }) {
+                    TurnProxyManager.TurnStartResult.Success -> {
+                        try {
+                            newState = withContext(Dispatchers.IO) {
+                                backend.setState(tunnel, state, configToUse)
+                            }
+                        } catch (e: Throwable) {
+                            cleanupFailedTurnStartup(goBackend)
+                            throw e
+                        }
                     }
-                    if (!turnStarted) {
-                        Log.w(TAG, "TURN proxy start returned false, but tunnel is up")
+                    is TurnProxyManager.TurnStartResult.Failure -> {
+                        cleanupFailedTurnStartup(goBackend)
+                        throw IllegalStateException(turnResult.message)
                     }
-                } else {
-                    Log.w(TAG, "TURN not enabled for tunnel ${tunnel.name}, skipping")
                 }
+            } else {
+                newState = withContext(Dispatchers.IO) { backend.setState(tunnel, state, configToUse) }
             }
 
             if (newState == Tunnel.State.UP) {

--- a/ui/src/main/java/com/wireguard/android/turn/TurnProxyManager.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnProxyManager.kt
@@ -32,6 +32,11 @@ import java.net.Inet4Address
  */
 class TurnProxyManager(private val context: Context) {
     private val scope = CoroutineScope(Dispatchers.IO)
+
+    sealed interface TurnStartResult {
+        data object Success : TurnStartResult
+        data class Failure(val code: Int, val message: String) : TurnStartResult
+    }
     
     // State
     private var activeTunnelName: String? = null
@@ -100,10 +105,14 @@ class TurnProxyManager(private val context: Context) {
             attempts++
             Log.d(TAG, "Starting TURN for $name (Attempt $attempts)")
             
-            val success = startForTunnelInternal(name, settings)
-            if (success) {
-                Log.d(TAG, "TURN restarted successfully on attempt $attempts")
-                return // Exit loop on success
+            when (val result = startForTunnelInternal(name, settings)) {
+                TurnStartResult.Success -> {
+                    Log.d(TAG, "TURN restarted successfully on attempt $attempts")
+                    return // Exit loop on success
+                }
+                is TurnStartResult.Failure -> {
+                    Log.w(TAG, "TURN restart attempt $attempts failed: ${result.message}")
+                }
             }
 
             // Exponential backoff logic
@@ -128,9 +137,9 @@ class TurnProxyManager(private val context: Context) {
     private val operationMutex = kotlinx.coroutines.sync.Mutex()
 
     /**
-     * Called from TurnManager when the tunnel is established.
+     * Called once VpnService is ready and TURN should gate WireGuard startup.
      */
-    suspend fun onTunnelEstablished(tunnelName: String, turnSettings: TurnSettings?): Boolean {
+    suspend fun onTunnelEstablished(tunnelName: String, turnSettings: TurnSettings?): TurnStartResult {
         Log.d(TAG, "onTunnelEstablished called for tunnel: $tunnelName")
 
         // Reset state for new session
@@ -144,35 +153,38 @@ class TurnProxyManager(private val context: Context) {
 
         if (turnSettings == null || !turnSettings.enabled) {
             Log.d(TAG, "TURN not enabled, skipping")
-            return true
+            return TurnStartResult.Success
         }
 
-        val success = startForTunnelInternal(tunnelName, turnSettings)
+        val result = startForTunnelInternal(tunnelName, turnSettings)
 
-        // After initial start, allow network changes to trigger restarts
-        // We delay slightly to ensure we don't catch the immediate network fluctuation caused by VPN itself
-        scope.launch {
-            delay(2000)
-            Log.d(TAG, "Initialization phase complete, network monitoring active")
+        if (result == TurnStartResult.Success) {
+            // After initial start, allow network changes to trigger restarts.
+            // We delay slightly to ensure we don't catch the immediate network fluctuation caused by VPN itself.
+            scope.launch {
+                delay(2000)
+                Log.d(TAG, "Initialization phase complete, network monitoring active")
+            }
         }
 
-        return success
+        return result
     }
 
-    suspend fun startForTunnel(tunnelName: String, settings: TurnSettings): Boolean {
+    suspend fun startForTunnel(tunnelName: String, settings: TurnSettings): TurnStartResult {
         return startForTunnelInternal(tunnelName, settings)
     }
     
-    private suspend fun startForTunnelInternal(tunnelName: String, settings: TurnSettings): Boolean =
+    private suspend fun startForTunnelInternal(tunnelName: String, settings: TurnSettings): TurnStartResult =
         withContext(Dispatchers.IO) {
             operationMutex.lock()
             try {
                 if (!currentCoroutineContext().isActive) {
                     Log.d(TAG, "startForTunnelInternal cancelled before execution")
-                    return@withContext false
+                    return@withContext TurnStartResult.Failure(ERROR_START_CANCELLED, "TURN startup cancelled")
                 }
 
                 val instance = instances.getOrPut(tunnelName) { Instance() }
+                instance.running = false
 
                 Log.d(TAG, "Stopping any existing TURN proxy...")
                 TurnBackend.wgTurnProxyStop()
@@ -183,7 +195,10 @@ class TurnProxyManager(private val context: Context) {
                 val jniReady = TurnBackend.waitForVpnServiceRegistered(2000)
                 if (!jniReady) {
                     Log.e(TAG, "TIMEOUT waiting for JNI registration!")
-                    return@withContext false
+                    return@withContext TurnStartResult.Failure(
+                        ERROR_VPN_SERVICE_NOT_READY,
+                        "TURN startup failed: VpnService was not registered in time"
+                    )
                 }
 
                 // If network is still null, try one quick re-poll from monitor
@@ -213,17 +228,21 @@ class TurnProxyManager(private val context: Context) {
                 )
 
                 val listenAddr = "127.0.0.1:${settings.localPort}"
-                if (ret == 0) {
+                if (ret == TurnBackend.WG_TURN_PROXY_SUCCESS) {
                     instance.running = true
                     val msg = "TURN started for tunnel \"$tunnelName\" listening on $listenAddr"
                     Log.d(TAG, msg)
                     appendLogLine(tunnelName, msg)
-                    true
+                    TurnStartResult.Success
                 } else {
-                    val msg = "Failed to start TURN proxy (error $ret)"
+                    val msg = when (ret) {
+                        TurnBackend.WG_TURN_PROXY_ERROR_VK_LINK_EXPIRED ->
+                            "TURN startup failed: VK call link expired"
+                        else -> "Failed to start TURN proxy (error $ret)"
+                    }
                     Log.e(TAG, msg)
                     appendLogLine(tunnelName, msg)
-                    false
+                    TurnStartResult.Failure(ret, msg)
                 }
             } finally {
                 operationMutex.unlock()
@@ -236,9 +255,6 @@ class TurnProxyManager(private val context: Context) {
             activeTunnelName = null
             activeSettings = null
             lastKnownNetwork = null
-
-            // Reset VpnService reference
-            TurnBackend.onVpnServiceCreated(null)
 
             // Stop TURN proxy BEFORE acquiring mutex to avoid deadlock with startup wait
             TurnBackend.wgTurnProxyStop()
@@ -299,5 +315,7 @@ class TurnProxyManager(private val context: Context) {
     companion object {
         private const val TAG = "WireGuard/TurnProxyManager"
         private const val MAX_LOG_CHARS = 128 * 1024
+        private const val ERROR_VPN_SERVICE_NOT_READY = -1001
+        private const val ERROR_START_CANCELLED = -1002
     }
 }


### PR DESCRIPTION
### Проблема

WireGuard запускался до завершения инициализации TURN.

В случае fallback на ручную VK captcha через WebView это приводило к тому,
что WebView работал уже под активным VPN (VpnService + WG tunnel), из-за чего:
- WebView мог зависать
- captcha не загружалась или не проходилась

### Причина

TURN использует VpnService только для вызова protect() на сокетах,
чтобы исключить их из VPN маршрутизации.

Однако WireGuard поднимался слишком рано и начинал влиять на сетевую среду.

### Решение

Порядок запуска изменён:

1. подготовка VpnService
2. регистрация в TurnBackend
3. запуск TURN proxy
4. ожидание готовности TURN
5. запуск WireGuard

### Изменения

- Разделены этапы подготовки VpnService и запуска WG (GoBackend)
- Обновлён порядок запуска в TunnelManager
- TURN теперь является обязательным этапом перед запуском WG
- Добавлен cleanup при ошибке запуска TURN

## Изменения в коде

- в `GoBackend` выделен отдельный шаг подготовки `VpnService` без немедленного старта WG
- добавлены методы:
  - `ensureVpnServiceReady()`
  - `stopVpnServiceIfIdle()`
- в `TunnelManager` изменён порядок запуска:
  - раньше: `backend.setState(UP)` -> `TurnProxyManager.onTunnelEstablished(...)`
  - теперь: `ensureVpnServiceReady()` -> `TurnProxyManager.onTunnelEstablished(...)` -> `backend.setState(UP, ...)`
- при неуспешном TURN startup выполняется cleanup:
  - остановка TURN
  - остановка idle `VpnService`
  - возврат state/UI в неактивное состояние
- в `TurnBackend` / `TurnProxyManager` добавлена более явная обработка результата запуска TURN

### Результат

- WebView captcha выполняется вне активного VPN
- Исключены конфликты сетевого трафика
- Поведение стало более стабильным и детерминированным
