### PR TITLE
Remove upper limit on TURN streams and streams-per-credentials

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -57,7 +57,7 @@ AllowedIPs = 0.0.0.0/0
 #@wgt:IPPort = 1.2.3.4:56000
 #@wgt:VKLink = https://vk.com/call/join/...
 #@wgt:Mode = vk_link              # Auth mode: vk_link or wb
-#@wgt:PeerType = proxy_v2          # proxy_v2 | proxy_v1 | wireguard
+#@wgt:PeerType = turncoat_v3       # turncoat_v3 | proxy_v2 | proxy_v1 | wireguard
 #@wgt:StreamNum = 4
 #@wgt:LocalPort = 9000
 #@wgt:StreamsPerCred = 4           # Streams per credentials cache
@@ -66,9 +66,11 @@ AllowedIPs = 0.0.0.0/0
 #@wgt:TurnIP = 155.212.199.166      # Override TURN server IP
 #@wgt:TurnPort = 19302              # Override TURN server port
 #@wgt:WatchdogTimeout = 30          # Inactivity timeout (sec, 0=disabled)
+#@wgt:WrapKey = <64-hex-key>        # TURNcoat v3 WRAP/WARP key (empty=off)
 ```
 
 **Note:** The `PeerType` parameter determines the operating mode:
+- `turncoat_v3` — TURNcoat v3: DTLS + 19-byte Session ID handshake, compatible with the `TURNcoat` `v3` branch server
 - `proxy_v2` (default) — DTLS with Session ID transmission for stream aggregation (server: [kiper292/vk-turn-proxy](https://github.com/kiper292/vk-turn-proxy))
 - `proxy_v1` — DTLS without Session ID handshake (server: [cacggghp/vk-turn-proxy](https://github.com/cacggghp/vk-turn-proxy))
 - `wireguard` — no DTLS, direct relay (NoDTLS, for debugging or direct connection)
@@ -76,7 +78,9 @@ AllowedIPs = 0.0.0.0/0
 **Watchdog Timeout:** The `WatchdogTimeout` parameter enables inactivity monitoring for DTLS mode:
 - `0` (default) — watchdog disabled
 - `≥5` — timeout in seconds; if no packets are received from the TURN server within this time, the connection is re-established
-- Applies only to `proxy_v2` and `proxy_v1` modes
+- Applies only to `turncoat_v3`, `proxy_v2`, and `proxy_v1` modes
+
+**WRAP/WARP:** The `WrapKey` parameter enables ChaCha20 DTLS-packet obfuscation for TURNcoat `v3`. It must match the server `-wrap-key`; leave it empty for legacy behavior.
 
 For more technical details, see [info/TURN_INTEGRATION_DETAILS.md](info/TURN_INTEGRATION_DETAILS.md).
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ AllowedIPs = 0.0.0.0/0
 #@wgt:IPPort = 1.2.3.4:56000
 #@wgt:VKLink = https://vk.com/call/join/...
 #@wgt:Mode = vk_link              # Режим авторизации: vk_link или wb
-#@wgt:PeerType = proxy_v2          # proxy_v2 | proxy_v1 | wireguard
+#@wgt:PeerType = turncoat_v3       # turncoat_v3 | proxy_v2 | proxy_v1 | wireguard
 #@wgt:StreamNum = 4
 #@wgt:LocalPort = 9000
 #@wgt:StreamsPerCred = 4           # Потоков на один кэш credentials
@@ -68,9 +68,11 @@ AllowedIPs = 0.0.0.0/0
 #@wgt:TurnIP = 155.212.199.166      # Переопределить IP TURN сервера
 #@wgt:TurnPort = 19302              # Переопределить порт TURN сервера
 #@wgt:WatchdogTimeout = 30          # Таймаут неактивности (сек, 0=отключен)
+#@wgt:WrapKey = <64-hex-key>        # WRAP/WARP ключ TURNcoat v3 (пусто=отключено)
 ```
 
 **Примечание:** Параметр `PeerType` определяет режим работы:
+- `turncoat_v3` — TURNcoat v3: DTLS + 19-byte Session ID handshake, совместим с сервером `TURNcoat` ветки `v3`
 - `proxy_v2` (по умолчанию) — DTLS с передачей Session ID для агрегации потоков (сервер: [kiper292/vk-turn-proxy](https://github.com/kiper292/vk-turn-proxy))
 - `proxy_v1` — DTLS без Session ID handshake (сервер: [cacggghp/vk-turn-proxy](https://github.com/cacggghp/vk-turn-proxy))
 - `wireguard` — без DTLS, прямой relay (NoDTLS, для отладки или прямого подключения)
@@ -78,7 +80,9 @@ AllowedIPs = 0.0.0.0/0
 **Watchdog Timeout:** Параметр `WatchdogTimeout` активирует контроль неактивности для DTLS режима:
 - `0` (по умолчанию) — watchdog отключен
 - `≥5` — таймаут в секундах; если пакеты не получаются от TURN сервера в течение указанного времени, соединение переподключается
-- Применяется только к режимам `proxy_v2` и `proxy_v1`
+
+**WRAP/WARP:** Параметр `WrapKey` включает ChaCha20-обфускацию DTLS-пакетов для TURNcoat `v3`. Ключ должен совпадать с `server -wrap-key`; пустое значение сохраняет старое поведение.
+- Применяется только к режимам `turncoat_v3`, `proxy_v2` и `proxy_v1`
 
 Для получения подробной технической информации см. [info/TURN_INTEGRATION_DETAILS.md](info/TURN_INTEGRATION_DETAILS.md).
 

--- a/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
@@ -150,6 +150,7 @@ public final class TurnBackend {
             String peerType,
             int streamsPerCred,
             int watchdogTimeout,
+            String wrapKey,
             long networkHandle
     );
     public static native void wgTurnProxyStop();

--- a/tunnel/tools/libwg-go/Makefile
+++ b/tunnel/tools/libwg-go/Makefile
@@ -20,9 +20,11 @@ export GOARCH := $(NDK_GO_ARCH_MAP_$(ANDROID_ARCH_NAME))
 export GOOS := android
 export CGO_ENABLED := 1
 
+GO_SOURCES := $(wildcard *.go)
+
 default: $(DESTDIR)/libwg-go.so
 
-$(DESTDIR)/libwg-go.so: go.mod
+$(DESTDIR)/libwg-go.so: go.mod go.sum $(GO_SOURCES)
 	go build -tags linux -ldflags="-checklinkname=0 -X golang.zx2c4.com/wireguard/ipc.socketDirectory=/data/data/$(ANDROID_PACKAGE_NAME)/cache/wireguard -buildid=" -v -trimpath -buildvcs=false -o "$@" -buildmode c-shared
 
 .DELETE_ON_ERROR:

--- a/tunnel/tools/libwg-go/jni.c
+++ b/tunnel/tools/libwg-go/jni.c
@@ -16,7 +16,7 @@ extern int wgGetSocketV4(int handle);
 extern int wgGetSocketV6(int handle);
 extern char *wgGetConfig(int handle);
 extern char *wgVersion();
-extern int wgTurnProxyStart(const char *peer_addr, const char *vklink, const char *mode, int n, int udp, const char *listen_addr, const char *turn_ip, int turn_port, const char *peer_type, int streams_per_cred, int watchdog_timeout, long long network_handle);
+extern int wgTurnProxyStart(const char *peer_addr, const char *vklink, const char *mode, int n, int udp, const char *listen_addr, const char *turn_ip, int turn_port, const char *peer_type, int streams_per_cred, int watchdog_timeout, const char *wrap_key, long long network_handle);
 extern void wgTurnProxyStop();
 extern void wgNotifyNetworkChange();
 extern const char* getNetworkDnsServers(long long network_handle);
@@ -292,7 +292,7 @@ JNIEXPORT jstring JNICALL Java_com_wireguard_android_backend_GoBackend_wgVersion
 	return ret;
 }
 
-JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProxyStart(JNIEnv *env, jclass c, jstring peer_addr, jstring vklink, jstring mode, jint n, jint useUdp, jstring listen_addr, jstring turn_ip, jint turn_port, jstring peer_type, jint streams_per_cred, jint watchdog_timeout, jlong network_handle)
+JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProxyStart(JNIEnv *env, jclass c, jstring peer_addr, jstring vklink, jstring mode, jint n, jint useUdp, jstring listen_addr, jstring turn_ip, jint turn_port, jstring peer_type, jint streams_per_cred, jint watchdog_timeout, jstring wrap_key, jlong network_handle)
 {
 	const char *peer_addr_jni = (*env)->GetStringUTFChars(env, peer_addr, 0);
 	const char *vklink_jni = (*env)->GetStringUTFChars(env, vklink, 0);
@@ -300,6 +300,7 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	const char *listen_addr_jni = (*env)->GetStringUTFChars(env, listen_addr, 0);
 	const char *turn_ip_jni = (*env)->GetStringUTFChars(env, turn_ip, 0);
 	const char *peer_type_jni = (*env)->GetStringUTFChars(env, peer_type, 0);
+	const char *wrap_key_jni = (*env)->GetStringUTFChars(env, wrap_key, 0);
 
 	// Duplicate strings to avoid MTE issues with JNI-tagged pointers during Go execution
 	char *peer_addr_str = peer_addr_jni ? strdup(peer_addr_jni) : NULL;
@@ -308,10 +309,11 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	char *listen_addr_str = listen_addr_jni ? strdup(listen_addr_jni) : NULL;
 	char *turn_ip_str = turn_ip_jni ? strdup(turn_ip_jni) : NULL;
 	char *peer_type_str = peer_type_jni ? strdup(peer_type_jni) : NULL;
+	char *wrap_key_str = wrap_key_jni ? strdup(wrap_key_jni) : NULL;
 
 	update_current_network(env, network_handle);
 
-	int ret = wgTurnProxyStart(peer_addr_str, vklink_str, mode_str, (int)n, (int)useUdp, listen_addr_str, turn_ip_str, (int)turn_port, peer_type_str, (int)streams_per_cred, (int)watchdog_timeout, (long long)network_handle);
+	int ret = wgTurnProxyStart(peer_addr_str, vklink_str, mode_str, (int)n, (int)useUdp, listen_addr_str, turn_ip_str, (int)turn_port, peer_type_str, (int)streams_per_cred, (int)watchdog_timeout, wrap_key_str, (long long)network_handle);
 
 	(*env)->ReleaseStringUTFChars(env, peer_addr, peer_addr_jni);
 	(*env)->ReleaseStringUTFChars(env, vklink, vklink_jni);
@@ -319,6 +321,7 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	(*env)->ReleaseStringUTFChars(env, listen_addr, listen_addr_jni);
 	(*env)->ReleaseStringUTFChars(env, turn_ip, turn_ip_jni);
 	(*env)->ReleaseStringUTFChars(env, peer_type, peer_type_jni);
+	(*env)->ReleaseStringUTFChars(env, wrap_key, wrap_key_jni);
 
 	free(peer_addr_str);
 	free(vklink_str);
@@ -326,6 +329,7 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	free(listen_addr_str);
 	free(turn_ip_str);
 	free(peer_type_str);
+	free(wrap_key_str);
 
 	return ret;
 }

--- a/tunnel/tools/libwg-go/turn-client.go
+++ b/tunnel/tools/libwg-go/turn-client.go
@@ -69,45 +69,47 @@ var turnHTTPClient = &http.Client{
 			Timeout: 30 * time.Second,
 			Control: protectControl,
 		}).DialContext,
-		MaxIdleConns: 100,
+		MaxIdleConns:    100,
 		IdleConnTimeout: 90 * time.Second,
 	},
 }
 
 type stream struct {
-	ctx       context.Context
-	id        int
-	in        chan []byte
-	out       net.PacketConn
-	peer      atomic.Pointer[net.Addr] // Last seen addr from WireGuard
-	ready     atomic.Bool
-	sessionID []byte
-	cert      *tls.Certificate
+	ctx             context.Context
+	id              int
+	in              chan []byte
+	out             net.PacketConn
+	peer            atomic.Pointer[net.Addr] // Last seen addr from WireGuard
+	ready           atomic.Bool
+	sessionID       []byte
+	cert            *tls.Certificate
 	watchdogTimeout int
+	wrapKey         []byte
 }
 
-const iPacketBuffMaxSize = 2048;
+const iPacketBuffMaxSize = 2048
 
 var packetPool = sync.Pool{
-    New: func() interface{} {
-        return make([]byte, iPacketBuffMaxSize)
-    },
+	New: func() interface{} {
+		return make([]byte, iPacketBuffMaxSize)
+	},
 }
 
 // Metrics for diagnostics
 var (
-	dtlsTxDropCount   atomic.Uint64      // Drops in DTLS TX goroutine
-	dtlsRxErrorCount  atomic.Uint64      // Errors in DTLS RX goroutine
-	relayTxErrorCount atomic.Uint64      // Errors in relay TX
-	relayRxErrorCount atomic.Uint64      // Errors in relay RX
-	noDtlsTxDropCount atomic.Uint64      // Drops in NoDTLS TX
-	noDtlsRxErrorCount atomic.Uint64     // Errors in NoDTLS RX
+	dtlsTxDropCount    atomic.Uint64 // Drops in DTLS TX goroutine
+	dtlsRxErrorCount   atomic.Uint64 // Errors in DTLS RX goroutine
+	relayTxErrorCount  atomic.Uint64 // Errors in relay TX
+	relayRxErrorCount  atomic.Uint64 // Errors in relay RX
+	noDtlsTxDropCount  atomic.Uint64 // Drops in NoDTLS TX
+	noDtlsRxErrorCount atomic.Uint64 // Errors in NoDTLS RX
 )
 
 func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- struct{}, turnIp string, turnPort int, peerType string) {
 	for {
 		select {
-		case <-s.ctx.Done(): return
+		case <-s.ctx.Done():
+			return
 		default:
 		}
 
@@ -120,7 +122,9 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 				return fmt.Errorf("credentials function not initialized")
 			}
 			user, pass, addr, err := globalGetCreds(sCtx, link, s.id)
-			if err != nil { return fmt.Errorf("TURN creds failed: %w", err) }
+			if err != nil {
+				return fmt.Errorf("TURN creds failed: %w", err)
+			}
 
 			// Override TURN address if provided
 			if turnIp != "" {
@@ -148,12 +152,16 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 			var turnConn net.PacketConn
 			if udp {
 				c, err := dialer.DialContext(sCtx, "udp", addr)
-				if err != nil { return fmt.Errorf("TURN UDP dial failed: %w", err) }
+				if err != nil {
+					return fmt.Errorf("TURN UDP dial failed: %w", err)
+				}
 				defer c.Close()
 				turnConn = &connectedUDPConn{c.(*net.UDPConn)}
 			} else {
 				c, err := dialer.DialContext(sCtx, "tcp", addr)
-				if err != nil { return fmt.Errorf("TURN TCP dial failed: %w", err) }
+				if err != nil {
+					return fmt.Errorf("TURN TCP dial failed: %w", err)
+				}
 				defer c.Close()
 				turnConn = turn.NewSTUNConn(c)
 			}
@@ -162,7 +170,9 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 				STUNServerAddr: addr, TURNServerAddr: addr, Username: user, Password: pass,
 				Conn: turnConn, LoggerFactory: logging.NewDefaultLoggerFactory(),
 			})
-			if err != nil { return fmt.Errorf("TURN client creation failed: %w", err) }
+			if err != nil {
+				return fmt.Errorf("TURN client creation failed: %w", err)
+			}
 			defer client.Close()
 			if err := client.Listen(); err != nil {
 				// Check if this is an authentication error (stale credentials)
@@ -189,9 +199,7 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 			if peerType == "wireguard" {
 				return s.runNoDTLS(sCtx, relayConn, peer, okchan)
 			}
-			// proxy_v2 and proxy_v1 both use DTLS, but v2 sends session+stream handshake
-			sendHandshake := peerType != "proxy_v1"
-			return s.runDTLS(sCtx, relayConn, peer, okchan, sendHandshake)
+			return s.runDTLS(sCtx, relayConn, peer, okchan, peerType)
 		}()
 
 		if err != nil && s.ctx.Err() == nil {
@@ -218,15 +226,17 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 
 	// WireGuard backend (s.in channel) -> TURN -> WireGuard server (TX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		for {
 			select {
-			case <-sCtx.Done(): return
+			case <-sCtx.Done():
+				return
 			case b := <-s.in:
-                _, err := relayConn.WriteTo(b, peer)
-                packetPool.Put(b[:cap(b)])
+				_, err := relayConn.WriteTo(b, peer)
+				packetPool.Put(b[:cap(b)])
 
-                if err != nil {
+				if err != nil {
 					noDtlsTxDropCount.Add(1)
 					turnLog("[STREAM %d] TX error: %v", s.id, err)
 					return
@@ -237,7 +247,8 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 
 	// WireGuard server -> TURN -> WireGuard backend (s.out socket) (RX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
 			n, from, err := relayConn.ReadFrom(buf)
@@ -248,6 +259,9 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 			}
 			if from.String() == peer.String() {
 				addr := s.peer.Load()
+				if addr == nil {
+					addr = globalWgPeer.Load()
+				}
 				if addr == nil {
 					turnLog("[STREAM %d] RX: no peer address yet", s.id)
 					continue
@@ -262,16 +276,31 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 	}()
 
 	s.ready.Store(true)
-	select { case okchan <- struct{}{}: default: }
+	select {
+	case okchan <- struct{}{}:
+	default:
+	}
 
 	wg.Wait()
 	return nil
 }
 
 // runDTLS handles packet relay with DTLS obfuscation
-func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *net.UDPAddr, okchan chan<- struct{}, sendHandshake bool) error {
+func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *net.UDPAddr, okchan chan<- struct{}, peerType string) error {
 	sCtx, sCancel := context.WithCancel(ctx)
 	defer sCancel()
+
+	relayWire := relayConn
+	if len(s.wrapKey) > 0 {
+		wrapped, err := newWrapPacketConn(relayWire, s.wrapKey)
+		if err != nil {
+			return fmt.Errorf("wrap setup failed: %w", err)
+		}
+		relayWire = wrapped
+		turnLog("[STREAM %d] WRAP enabled for relay transport", s.id)
+	} else if peerType == "turncoat_v3" {
+		turnLog("[STREAM %d] WRAP key is empty for turncoat_v3", s.id)
+	}
 
 	var dtlsConn *dtls.Conn
 
@@ -281,11 +310,13 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	dtlsConn, err := dtls.Client(c1, peer, &dtls.Config{
 		Certificates: []tls.Certificate{*s.cert}, InsecureSkipVerify: true,
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		CipherSuites: []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		ExtendedMasterSecret:  dtls.RequireExtendedMasterSecret,
+		CipherSuites:          []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 		ConnectionIDGenerator: dtls.OnlySendCIDGenerator(),
 	})
-	if err != nil { return fmt.Errorf("DTLS client creation failed: %w", err) }
+	if err != nil {
+		return fmt.Errorf("DTLS client creation failed: %w", err)
+	}
 	defer dtlsConn.Close()
 
 	wg := sync.WaitGroup{}
@@ -299,12 +330,15 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	// DTLS <-> Relay (via Pipe) - MUST start before handshake
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
 			n, _, err := c2.ReadFrom(buf)
-			if err != nil { return }
-			if _, err := relayConn.WriteTo(buf[:n], peer); err != nil {
+			if err != nil {
+				return
+			}
+			if _, err := relayWire.WriteTo(buf[:n], peer); err != nil {
 				relayTxErrorCount.Add(1)
 				turnLog("[STREAM %d] Relay TX error: %v", s.id, err)
 				return
@@ -313,10 +347,11 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 	}()
 
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
-			n, from, err := relayConn.ReadFrom(buf)
+			n, from, err := relayWire.ReadFrom(buf)
 			if err != nil {
 				relayRxErrorCount.Add(1)
 				turnLog("[STREAM %d] Relay RX error: %v", s.id, err)
@@ -339,7 +374,8 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 		defer ticker.Stop()
 		for {
 			select {
-			case <-sCtx.Done(): return
+			case <-sCtx.Done():
+				return
 			case <-ticker.C:
 				deadline := time.Now().Add(30 * time.Second)
 				relayConn.SetDeadline(deadline)
@@ -362,8 +398,20 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 	dtlsConn.SetDeadline(time.Time{})
 	turnLog("[STREAM %d] DTLS handshake SUCCESS", s.id)
 
-	// Session ID + Stream ID Handshake (17 bytes total) — only for Proxy v2
-	if sendHandshake {
+	switch peerType {
+	case "turncoat_v3":
+		dtlsConn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		handshakeBuf := make([]byte, 19)
+		handshakeBuf[0] = 0x54
+		handshakeBuf[1] = 0x43
+		handshakeBuf[2] = 2
+		copy(handshakeBuf[3:], s.sessionID)
+
+		if _, err := dtlsConn.Write(handshakeBuf); err != nil {
+			return fmt.Errorf("turncoat v3 session handshake failed: %w", err)
+		}
+		dtlsConn.SetWriteDeadline(time.Time{})
+	case "proxy_v2":
 		dtlsConn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		handshakeBuf := make([]byte, 17)
 		copy(handshakeBuf[:16], s.sessionID)
@@ -376,7 +424,10 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 	}
 
 	s.ready.Store(true)
-	select { case okchan <- struct{}{}: default: }
+	select {
+	case okchan <- struct{}{}:
+	default:
+	}
 
 	var lastRx atomic.Int64
 	lastRx.Store(time.Now().Unix())
@@ -385,15 +436,17 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	// WireGuard -> DTLS (TX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		for {
 			select {
-			case <-sCtx.Done(): return
+			case <-sCtx.Done():
+				return
 			case b := <-s.in:
 
 				// Watchdog (only active if watchdogTimeout > 0)
 				if s.watchdogTimeout > 0 && time.Since(time.Unix(lastRx.Load(), 0)) > time.Duration(s.watchdogTimeout)*time.Second {
-				    packetPool.Put(b[:cap(b)])
+					packetPool.Put(b[:cap(b)])
 					dtlsTxDropCount.Add(1)
 					turnLog("[STREAM %d] TX watchdog timeout (%ds)", s.id, s.watchdogTimeout)
 					return
@@ -413,7 +466,8 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	// DTLS -> WireGuard (RX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
 			n, err := dtlsConn.Read(buf)
@@ -423,7 +477,11 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 				return
 			}
 			lastRx.Store(time.Now().Unix())
-			if last := s.peer.Load(); last != nil {
+			last := s.peer.Load()
+			if last == nil {
+				last = globalWgPeer.Load()
+			}
+			if last != nil {
 				if _, err := s.out.WriteTo(buf[:n], *last); err != nil {
 					dtlsRxErrorCount.Add(1)
 					turnLog("[STREAM %d] RX write error: %v", s.id, err)
@@ -442,8 +500,15 @@ var turnMutex sync.Mutex
 
 // Global credentials function for mode selection (set by wgTurnProxyStart)
 var globalGetCreds getCredsFunc
+
+// Most recently observed local WG endpoint. Server-side session aggregation
+// (turncoat_v3) load-balances inbound bytes round-robin across streams, so a
+// reply may arrive on a stream whose own .peer hasn't been populated yet —
+// without a shared fallback, those packets get silently dropped.
+var globalWgPeer atomic.Pointer[net.Addr]
+
 //export wgTurnProxyStart
-func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int, udp C.int, listenAddrC *C.char, turnIpC *C.char, turnPortC C.int, peerTypeC *C.char, streamsPerCredC C.int, watchdogTimeoutC C.int, networkHandleC C.longlong) int32 {
+func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int, udp C.int, listenAddrC *C.char, turnIpC *C.char, turnPortC C.int, peerTypeC *C.char, streamsPerCredC C.int, watchdogTimeoutC C.int, wrapKeyC *C.char, networkHandleC C.longlong) int32 {
 	// Force initialization of resolver and HTTP client with current environment
 	wgNotifyNetworkChange()
 
@@ -466,11 +531,24 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 	peerType := C.GoString(peerTypeC)
 	streamsPerCred = int(streamsPerCredC)
 	watchdogTimeout := int(watchdogTimeoutC)
+	wrapKeyHex := strings.TrimSpace(C.GoString(wrapKeyC))
 	networkHandle := int64(networkHandleC)
 
-	turnLog("[PROXY] Hub starting on %s (streams=%d, mode=%s, peerType=%s, streamsPerCred=%d, watchdogTimeout=%d, networkHandle=%d)", listenAddr, int(n), mode, peerType, streamsPerCred, watchdogTimeout, networkHandle)
+	var wrapKey []byte
+	if wrapKeyHex != "" {
+		parsed, err := parseWrapKeyHex(wrapKeyHex)
+		if err != nil {
+			turnLog("[PROXY] Invalid WRAP key: %v", err)
+			return -1
+		}
+		wrapKey = parsed
+	}
+
+	turnLog("[PROXY] Hub starting on %s (streams=%d, mode=%s, peerType=%s, streamsPerCred=%d, watchdogTimeout=%d, wrap=%t, networkHandle=%d)", listenAddr, int(n), mode, peerType, streamsPerCred, watchdogTimeout, len(wrapKey) > 0, networkHandle)
 	turnMutex.Lock()
-	if currentTurnCancel != nil { currentTurnCancel() }
+	if currentTurnCancel != nil {
+		currentTurnCancel()
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	currentTurnCancel = cancel
 	turnMutex.Unlock()
@@ -485,7 +563,9 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 		turnLog("[PROXY] Using VK Link credential mode")
 		parts := strings.Split(vklink, "join/")
 		link := parts[len(parts)-1]
-		if idx := strings.IndexAny(link, "/?#"); idx != -1 { link = link[:idx] }
+		if idx := strings.IndexAny(link, "/?#"); idx != -1 {
+			link = link[:idx]
+		}
 		globalGetCreds = func(ctx context.Context, lk string, streamID int) (string, string, string, error) {
 			return getCredsCached(ctx, lk, streamID, fetchVkCreds)
 		}
@@ -501,20 +581,28 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 			if err != nil {
 				turnLog("[DNS] Warning: failed to resolve peer: %v, using original", err)
 				peer, err = net.ResolveUDPAddr("udp", peerAddr)
-				if err != nil { return -1 }
+				if err != nil {
+					return -1
+				}
 			} else {
 				peerAddr = net.JoinHostPort(resolvedIP, port)
 				//turnLog("[DNS] Resolved peer %s -> %s", host, resolvedIP)
 				peer, err = net.ResolveUDPAddr("udp", peerAddr)
-				if err != nil { return -1 }
+				if err != nil {
+					return -1
+				}
 			}
 		} else {
 			peer, err = net.ResolveUDPAddr("udp", peerAddr)
-			if err != nil { return -1 }
+			if err != nil {
+				return -1
+			}
 		}
 	} else {
 		peer, err = net.ResolveUDPAddr("udp", peerAddr)
-		if err != nil { return -1 }
+		if err != nil {
+			return -1
+		}
 	}
 
 	// Determine link for VK mode (for WB mode, link is just "wb")
@@ -524,11 +612,15 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 	} else {
 		parts := strings.Split(vklink, "join/")
 		link = parts[len(parts)-1]
-		if idx := strings.IndexAny(link, "/?#"); idx != -1 { link = link[:idx] }
+		if idx := strings.IndexAny(link, "/?#"); idx != -1 {
+			link = link[:idx]
+		}
 	}
 
 	lc, err := net.ListenPacket("udp", listenAddr)
-	if err != nil { return -1 }
+	if err != nil {
+		return -1
+	}
 	context.AfterFunc(ctx, func() { lc.Close() })
 
 	// Generate fresh Session ID for every run to avoid server-side conflicts
@@ -545,7 +637,7 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 	ok := make(chan struct{}, int(n))
 	streams := make([]*stream, int(n))
 	for i := 0; i < int(n); i++ {
-		streams[i] = &stream{ctx: ctx, id: i, in: make(chan []byte, 512), out: lc, sessionID: sessionID, cert: &cert, watchdogTimeout: watchdogTimeout}
+		streams[i] = &stream{ctx: ctx, id: i, in: make(chan []byte, 512), out: lc, sessionID: sessionID, cert: &cert, watchdogTimeout: watchdogTimeout, wrapKey: wrapKey}
 		go streams[i].run(link, peer, udp != 0, ok, turnIp, turnPort, peerType)
 		time.Sleep(200 * time.Millisecond)
 	}
@@ -555,38 +647,39 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 		var lastUsed int = 0
 
 		for {
-		    b := packetPool.Get().([]byte)[:iPacketBuffMaxSize]
+			b := packetPool.Get().([]byte)[:iPacketBuffMaxSize]
 			nRead, addr, err := lc.ReadFrom(b)
 			if err != nil {
-			    packetPool.Put(b[:cap(b)])
-			    return
+				packetPool.Put(b[:cap(b)])
+				return
 			}
 
 			// Round-Robin selection
 			lastUsed = (lastUsed + 1) % nStreams
 
-            var s *stream
-            for i := 0; i < nStreams; i++ {
-            	st := streams[(lastUsed+i)%nStreams]
-            	if st.ready.Load() {
-            		s = st
-            		break
-            	}
-            }
+			var s *stream
+			for i := 0; i < nStreams; i++ {
+				st := streams[(lastUsed+i)%nStreams]
+				if st.ready.Load() {
+					s = st
+					break
+				}
+			}
 
-            if s == nil {
-                packetPool.Put(b[:cap(b)])
-            	continue
-            }
+			if s == nil {
+				packetPool.Put(b[:cap(b)])
+				continue
+			}
 
 			returnAddr := addr
 			s.peer.Store(&returnAddr)
+			globalWgPeer.Store(&returnAddr)
 
 			select {
 			case s.in <- b[:nRead]:
 				// Packet queued successfully
 			default:
-                packetPool.Put(b[:cap(b)])
+				packetPool.Put(b[:cap(b)])
 			}
 		}
 	}()
@@ -612,5 +705,6 @@ func wgTurnProxyStop() {
 	}
 }
 
-type connectedUDPConn struct { *net.UDPConn }
+type connectedUDPConn struct{ *net.UDPConn }
+
 func (c *connectedUDPConn) WriteTo(p []byte, _ net.Addr) (int, error) { return c.Write(p) }

--- a/tunnel/tools/libwg-go/wrap.go
+++ b/tunnel/tools/libwg-go/wrap.go
@@ -1,0 +1,91 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2026.
+ */
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/crypto/chacha20"
+)
+
+const (
+	wrapNonceLen = 12
+	wrapKeyLen   = 32
+)
+
+func parseWrapKeyHex(value string) ([]byte, error) {
+	key, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hex: %w", err)
+	}
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("must be %d bytes (got %d)", wrapKeyLen, len(key))
+	}
+	return key, nil
+}
+
+func newWrapPacketConn(inner net.PacketConn, key []byte) (net.PacketConn, error) {
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("wrap: key must be %d bytes (got %d)", wrapKeyLen, len(key))
+	}
+	keyCopy := append([]byte(nil), key...)
+	return &wrapPacketConn{inner: inner, key: keyCopy}, nil
+}
+
+type wrapPacketConn struct {
+	inner net.PacketConn
+	key   []byte
+}
+
+func (c *wrapPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	buf := make([]byte, len(p)+wrapNonceLen)
+	n, addr, err := c.inner.ReadFrom(buf)
+	if err != nil {
+		return 0, addr, err
+	}
+	if n < wrapNonceLen {
+		return 0, addr, errors.New("wrap: short packet")
+	}
+
+	nonce := buf[:wrapNonceLen]
+	ciphertext := buf[wrapNonceLen:n]
+	if len(ciphertext) > len(p) {
+		return 0, addr, errors.New("wrap: read buffer too small")
+	}
+	cipher, err := chacha20.NewUnauthenticatedCipher(c.key, nonce)
+	if err != nil {
+		return 0, addr, fmt.Errorf("wrap: cipher init: %w", err)
+	}
+	cipher.XORKeyStream(p[:len(ciphertext)], ciphertext)
+	return len(ciphertext), addr, nil
+}
+
+func (c *wrapPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	out := make([]byte, wrapNonceLen+len(p))
+	if _, err := rand.Read(out[:wrapNonceLen]); err != nil {
+		return 0, fmt.Errorf("wrap: nonce gen: %w", err)
+	}
+	cipher, err := chacha20.NewUnauthenticatedCipher(c.key, out[:wrapNonceLen])
+	if err != nil {
+		return 0, fmt.Errorf("wrap: cipher init: %w", err)
+	}
+	cipher.XORKeyStream(out[wrapNonceLen:], p)
+	if _, err := c.inner.WriteTo(out, addr); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *wrapPacketConn) Close() error                       { return c.inner.Close() }
+func (c *wrapPacketConn) LocalAddr() net.Addr                { return c.inner.LocalAddr() }
+func (c *wrapPacketConn) SetDeadline(t time.Time) error      { return c.inner.SetDeadline(t) }
+func (c *wrapPacketConn) SetReadDeadline(t time.Time) error  { return c.inner.SetReadDeadline(t) }
+func (c *wrapPacketConn) SetWriteDeadline(t time.Time) error { return c.inner.SetWriteDeadline(t) }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val pkg: String = providers.gradleProperty("wireguardPackageName").get()
+val targetAbi: String? = providers.gradleProperty("targetAbi").orNull
 
 plugins {
     alias(libs.plugins.android.application)
@@ -27,7 +28,7 @@ android {
         versionName = providers.gradleProperty("wireguardVersionName").get()
         buildConfigField("int", "MIN_SDK_VERSION", minSdk.toString())
         ndk {
-            abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a"))
+            abiFilters.addAll(targetAbi?.let { listOf(it) } ?: listOf("armeabi-v7a", "arm64-v8a"))
         }
     }
     packaging {

--- a/ui/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
+++ b/ui/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
@@ -68,6 +68,7 @@ class TunnelEditorFragment : BaseFragment(), MenuProvider {
         binding?.apply {
             val currentPeerType = config?.turn?.peerType ?: "proxy_v2"
             val peerTypeText = when (currentPeerType) {
+                "turncoat_v3" -> getString(R.string.turn_peer_type_turncoat_v3)
                 "proxy_v1" -> getString(R.string.turn_peer_type_proxy_v1)
                 "wireguard" -> getString(R.string.turn_peer_type_wireguard)
                 else -> getString(R.string.turn_peer_type_proxy_v2)
@@ -156,8 +157,10 @@ class TunnelEditorFragment : BaseFragment(), MenuProvider {
 
             val currentPeerType = config?.turn?.peerType ?: "proxy_v2"
             val peerTypeIndex = when (currentPeerType) {
-                "proxy_v1" -> 1
-                "wireguard" -> 2
+                "turncoat_v3" -> 0
+                "proxy_v2" -> 1
+                "proxy_v1" -> 2
+                "wireguard" -> 3
                 else -> 0
             }
             if (turnPeerTypeSpinner.text.isNotEmpty()) {
@@ -172,9 +175,10 @@ class TunnelEditorFragment : BaseFragment(), MenuProvider {
 
             turnPeerTypeSpinner.setOnItemClickListener { _, _, position, _ ->
                 config?.turn?.peerType = when (position) {
-                    1 -> "proxy_v1"
-                    2 -> "wireguard"
-                    else -> "proxy_v2"
+                    1 -> "proxy_v2"
+                    2 -> "proxy_v1"
+                    3 -> "wireguard"
+                    else -> "turncoat_v3"
                 }
             }
         }

--- a/ui/src/main/java/com/wireguard/android/turn/TurnProxyManager.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnProxyManager.kt
@@ -209,6 +209,7 @@ class TurnProxyManager(private val context: Context) {
                     settings.peerType,
                     settings.streamsPerCred,
                     settings.watchdogTimeout,
+                    settings.wrapKey,
                     networkHandle
                 )
 

--- a/ui/src/main/java/com/wireguard/android/turn/TurnSettings.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnSettings.kt
@@ -100,10 +100,10 @@ data class TurnSettings(
             if (settings.mode != "wb") {
                 require(settings.vkLink.isNotBlank()) { "VK link is empty" }
             }
-            require(settings.streams in 1..16) { "Streams must be between 1 and 16" }
+            require(settings.streams >= 1) { "Streams must be at least 1" }
             require(settings.localPort in 1..65535) { "Local port must be between 1 and 65535" }
             require(settings.peerType in listOf("proxy_v2", "proxy_v1", "wireguard")) { "Invalid peer type: ${settings.peerType}" }
-            require(settings.streamsPerCred in 1..16) { "Streams per credentials must be between 1 and 16" }
+            require(settings.streamsPerCred >= 1) { "Streams per credentials must be at least 1" }
 
             if (settings.turnPort != 0) {
                 require(settings.turnPort in 1..65535) { "TURN port must be between 1 and 65535" }

--- a/ui/src/main/java/com/wireguard/android/turn/TurnSettings.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnSettings.kt
@@ -19,9 +19,10 @@ data class TurnSettings(
     val localPort: Int = 9000,
     val turnIp: String = "",
     val turnPort: Int = 0,
-    val peerType: String = "proxy_v2",  // "proxy_v2", "proxy_v1", "wireguard"
+    val peerType: String = "proxy_v2",  // "turncoat_v3", "proxy_v2", "proxy_v1", "wireguard"
     val streamsPerCred: Int = 4,
     val watchdogTimeout: Int = 0,
+    val wrapKey: String = "",
 ) {
     fun toComments(): List<String> {
         val lines = mutableListOf(
@@ -40,6 +41,7 @@ data class TurnSettings(
         if (turnIp.isNotBlank()) lines.add("#@wgt:TurnIP = $turnIp")
         if (turnPort > 0) lines.add("#@wgt:TurnPort = $turnPort")
         if (watchdogTimeout > 0) lines.add("#@wgt:WatchdogTimeout = $watchdogTimeout")
+        if (wrapKey.isNotBlank()) lines.add("#@wgt:WrapKey = $wrapKey")
         return lines
     }
 
@@ -57,6 +59,7 @@ data class TurnSettings(
             var peerType: String? = null  // null means not set, will be determined from noDtls
             var streamsPerCred = 4
             var watchdogTimeout = 0
+            var wrapKey = ""
             var noDtlsLegacy = false
             var foundAny = false
 
@@ -82,6 +85,7 @@ data class TurnSettings(
                     "nodtls" -> noDtlsLegacy = value.toBoolean()  // legacy, for backward compatibility
                     "peertype" -> peerType = value
                     "streamspercred" -> streamsPerCred = value.toIntOrNull() ?: 4
+                    "wrapkey" -> wrapKey = value
                 }
             }
 
@@ -90,7 +94,7 @@ data class TurnSettings(
                 peerType = if (noDtlsLegacy) "wireguard" else "proxy_v2"
             }
 
-            return if (foundAny) TurnSettings(enabled, peer, vkLink, mode, streams, useUdp, localPort, turnIp, turnPort, peerType, streamsPerCred, watchdogTimeout) else null
+            return if (foundAny) TurnSettings(enabled, peer, vkLink, mode, streams, useUdp, localPort, turnIp, turnPort, peerType, streamsPerCred, watchdogTimeout, wrapKey) else null
         }
 
         fun validate(settings: TurnSettings): TurnSettings {
@@ -102,7 +106,7 @@ data class TurnSettings(
             }
             require(settings.streams >= 1) { "Streams must be at least 1" }
             require(settings.localPort in 1..65535) { "Local port must be between 1 and 65535" }
-            require(settings.peerType in listOf("proxy_v2", "proxy_v1", "wireguard")) { "Invalid peer type: ${settings.peerType}" }
+            require(settings.peerType in listOf("turncoat_v3", "proxy_v2", "proxy_v1", "wireguard")) { "Invalid peer type: ${settings.peerType}" }
             require(settings.streamsPerCred >= 1) { "Streams per credentials must be at least 1" }
 
             if (settings.turnPort != 0) {
@@ -111,6 +115,10 @@ data class TurnSettings(
 
             if (settings.watchdogTimeout > 0) {
                 require(settings.watchdogTimeout >= 5) { "Watchdog timeout must be at least 5 seconds or 0 to disable" }
+            }
+
+            if (settings.wrapKey.isNotBlank()) {
+                require(settings.wrapKey.matches(Regex("^[0-9a-fA-F]{64}$"))) { "WRAP key must be 64 hex characters" }
             }
 
             // Very small sanity check for host:port format; full validation is done later when applying.

--- a/ui/src/main/java/com/wireguard/android/turn/TurnSettingsStore.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnSettingsStore.kt
@@ -47,6 +47,8 @@ class TurnSettingsStore(private val context: Context) {
                     turnPort = json.optInt("turnPort", 0),
                     peerType = json.optString("peerType", peerTypeDefault),
                     streamsPerCred = json.optInt("streamsPerCred", 4),
+                    watchdogTimeout = json.optInt("watchdogTimeout", 0),
+                    wrapKey = json.optString("wrapKey", ""),
                 )
                 settings
             }
@@ -77,6 +79,8 @@ class TurnSettingsStore(private val context: Context) {
             .put("turnPort", settings.turnPort)
             .put("peerType", settings.peerType)
             .put("streamsPerCred", settings.streamsPerCred)
+            .put("watchdogTimeout", settings.watchdogTimeout)
+            .put("wrapKey", settings.wrapKey)
 
         file.parentFile?.mkdirs()
         FileOutputStream(file, false).use { stream ->
@@ -107,4 +111,3 @@ class TurnSettingsStore(private val context: Context) {
         private const val TAG = "WireGuard/TurnSettingsStore"
     }
 }
-

--- a/ui/src/main/java/com/wireguard/android/viewmodel/TurnSettingsProxy.kt
+++ b/ui/src/main/java/com/wireguard/android/viewmodel/TurnSettingsProxy.kt
@@ -166,7 +166,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         val parsedStreamsPerCred = streamsPerCred.toIntOrNull() ?: 4
 
         if (enabled) {
-            if (parsedStreams !in 1..16) {
+            if (parsedStreams < 1) {
                 throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, streams)
             }
 
@@ -182,7 +182,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
                 throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, watchdogTimeout)
             }
 
-            if (parsedStreamsPerCred !in 1..16) {
+            if (parsedStreamsPerCred < 1) {
                 throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, streamsPerCred)
             }
 

--- a/ui/src/main/java/com/wireguard/android/viewmodel/TurnSettingsProxy.kt
+++ b/ui/src/main/java/com/wireguard/android/viewmodel/TurnSettingsProxy.kt
@@ -84,6 +84,13 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         }
 
     @get:Bindable
+    var wrapKey: String = ""
+        set(value) {
+            field = value
+            notifyPropertyChanged(BR.wrapKey)
+        }
+
+    @get:Bindable
     var peerType: String = "proxy_v2"
         set(value) {
             field = value
@@ -118,6 +125,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         peerType = parcel.readString() ?: "proxy_v2"
         streamsPerCred = parcel.readString() ?: ""
         advancedExpanded = parcel.readInt() != 0
+        wrapKey = parcel.readString() ?: ""
     }
 
     constructor()
@@ -134,6 +142,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
             turnIp = other.turnIp
             turnPort = if (other.turnPort > 0) other.turnPort.toString() else ""
             watchdogTimeout = if (other.watchdogTimeout > 0) other.watchdogTimeout.toString() else ""
+            wrapKey = other.wrapKey
             peerType = other.peerType
             streamsPerCred = other.streamsPerCred.toString()
         }
@@ -155,6 +164,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         dest.writeString(peerType)
         dest.writeString(streamsPerCred)
         dest.writeInt(if (advancedExpanded) 1 else 0)
+        dest.writeString(wrapKey)
     }
 
     @Throws(BadConfigException::class)
@@ -164,6 +174,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         val parsedTurnPort = turnPort.toIntOrNull() ?: 0
         val parsedWatchdogTimeout = watchdogTimeout.toIntOrNull() ?: 0
         val parsedStreamsPerCred = streamsPerCred.toIntOrNull() ?: 4
+        val normalizedWrapKey = wrapKey.trim()
 
         if (enabled) {
             if (parsedStreams < 1) {
@@ -180,6 +191,10 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
 
             if (watchdogTimeout.isNotEmpty() && parsedWatchdogTimeout > 0 && parsedWatchdogTimeout < 5) {
                 throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, watchdogTimeout)
+            }
+
+            if (normalizedWrapKey.isNotBlank() && !normalizedWrapKey.matches(Regex("^[0-9a-fA-F]{64}$"))) {
+                throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, wrapKey)
             }
 
             if (parsedStreamsPerCred < 1) {
@@ -210,6 +225,7 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
             peerType = peerType,
             streamsPerCred = parsedStreamsPerCred,
             watchdogTimeout = parsedWatchdogTimeout,
+            wrapKey = normalizedWrapKey,
         )
         if (enabled) {
             TurnSettings.validate(settings)

--- a/ui/src/main/res/layout/tunnel_detail_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_detail_fragment.xml
@@ -345,7 +345,7 @@
                         android:id="@+id/turn_peer_type_text"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text='@{tunnel.turnSettings.peerType.equals("proxy_v1") ? @string/turn_peer_type_proxy_v1 : tunnel.turnSettings.peerType.equals("wireguard") ? @string/turn_peer_type_wireguard : @string/turn_peer_type_proxy_v2}'
+                        android:text='@{tunnel.turnSettings.peerType.equals("turncoat_v3") ? @string/turn_peer_type_turncoat_v3 : tunnel.turnSettings.peerType.equals("proxy_v1") ? @string/turn_peer_type_proxy_v1 : tunnel.turnSettings.peerType.equals("wireguard") ? @string/turn_peer_type_wireguard : @string/turn_peer_type_proxy_v2}'
                         android:textAppearance="?attr/textAppearanceBodyLarge"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/turn_peer_type_label" />

--- a/ui/src/main/res/layout/tunnel_editor_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_editor_fragment.xml
@@ -535,6 +535,27 @@
                             </com.google.android.material.textfield.TextInputLayout>
 
                             <com.google.android.material.textfield.TextInputLayout
+                                android:id="@+id/turn_wrap_key_layout"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_margin="4dp"
+                                android:enabled="@{config.turn.enabled}"
+                                android:hint="@string/turn_wrap_key"
+                                app:expandedHintEnabled="false">
+
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/turn_wrap_key_text"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:enabled="@{config.turn.enabled}"
+                                    android:hint="@string/turn_wrap_key_hint"
+                                    android:imeOptions="actionNext"
+                                    android:inputType="textNoSuggestions|textVisiblePassword"
+                                    android:maxLength="64"
+                                    android:text="@={config.turn.wrapKey}" />
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                            <com.google.android.material.textfield.TextInputLayout
                                 android:id="@+id/turn_local_port_layout"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -270,10 +270,12 @@
     <string name="turn_peer_type">Peer type</string>
     <string name="turn_peer_address">Peer address</string>
     <string-array name="turn_peer_type_options">
+        <item>@string/turn_peer_type_turncoat_v3</item>
         <item>@string/turn_peer_type_proxy_v2</item>
         <item>@string/turn_peer_type_proxy_v1</item>
         <item>@string/turn_peer_type_wireguard</item>
     </string-array>
+    <string name="turn_peer_type_turncoat_v3">TURNcoat v3</string>
     <string name="turn_peer_type_proxy_v2">Proxy v2</string>
     <string name="turn_peer_type_proxy_v1">Proxy v1</string>
     <string name="turn_peer_type_wireguard">WireGuard</string>
@@ -296,6 +298,8 @@
     <string name="turn_port_hint">(auto)</string>
     <string name="turn_watchdog_timeout">Watchdog timeout</string>
     <string name="turn_watchdog_timeout_hint">0=disabled, ≥5 sec</string>
+    <string name="turn_wrap_key">WRAP key</string>
+    <string name="turn_wrap_key_hint">64 hex chars, empty = off</string>
     <string name="turn_streams_per_cred">Streams per credentials</string>
     <string name="turn_streams_per_cred_hint">≥1 (default 4)</string>
     <string name="captcha_title">Verify You Are Human</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -285,7 +285,7 @@
     <string name="turn_vk_link">VK Calls link</string>
     <string name="turn_vk_link_hint">https://vk.ru/call/join/...</string>
     <string name="turn_streams">Streams (-n)</string>
-    <string name="turn_streams_hint">1-16 (default 4)</string>
+    <string name="turn_streams_hint">≥1 (default 4)</string>
     <string name="turn_local_port">Local port</string>
     <string name="turn_local_port_hint">1024-65535 (default 9000)</string>
     <string name="turn_use_udp">Use UDP</string>
@@ -297,7 +297,7 @@
     <string name="turn_watchdog_timeout">Watchdog timeout</string>
     <string name="turn_watchdog_timeout_hint">0=disabled, ≥5 sec</string>
     <string name="turn_streams_per_cred">Streams per credentials</string>
-    <string name="turn_streams_per_cred_hint">1-16 (default 4)</string>
+    <string name="turn_streams_per_cred_hint">≥1 (default 4)</string>
     <string name="captcha_title">Verify You Are Human</string>
     <string name="captcha_loading">Loading captcha…</string>
     <string name="captcha_error">Failed to solve captcha. Please try again.</string>


### PR DESCRIPTION
Streams (-n) and Streams per credentials are no longer capped at 16; only the lower bound (>=1) is enforced.