### PR TITLE
Add TURN WRAP support for Android client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         echo "release_notes_file=RELEASE_NOTES.md" >> $GITHUB_OUTPUT
 
     - name: Rename APK
-      run: mv ui/build/outputs/apk/release/ui-release.apk ui/build/outputs/apk/release/wg-turn-v${{ steps.version.outputs.version }}.apk
+      run: mv ui/build/outputs/apk/release/ui-release.apk ui/build/outputs/apk/release/wg-turn-${{ steps.version.outputs.VERSION }}.apk
 
     - name: Sign APK
       uses: r0adkll/sign-android-release@v1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-wireguardVersionCode=545
-wireguardVersionName=2.2.20
+wireguardVersionCode=546
+wireguardVersionName=2.2.21
 wireguardPackageName=com.wgturn.android
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
+++ b/tunnel/src/main/java/com/wireguard/android/backend/TurnBackend.java
@@ -156,6 +156,8 @@ public final class TurnBackend {
      * @param peerType Peer type
      * @param streamsPerCred Number of streams sharing one TURN credential cache
      * @param watchdogTimeout DTLS watchdog timeout in seconds, 0 to disable
+     * @param useWrap Whether WRAP obfuscation is enabled
+     * @param wrapKeyHex 32-byte WRAP key encoded as 64 hex characters
      * @param networkHandle Android network handle for socket binding
      * @return 0 on success, -1 on generic failure, -9000 when VK reports that the call link expired
      */
@@ -171,6 +173,8 @@ public final class TurnBackend {
             String peerType,
             int streamsPerCred,
             int watchdogTimeout,
+            int useWrap,
+            String wrapKeyHex,
             long networkHandle
     );
     public static native void wgTurnProxyStop();

--- a/tunnel/tools/libwg-go/jni.c
+++ b/tunnel/tools/libwg-go/jni.c
@@ -16,7 +16,7 @@ extern int wgGetSocketV4(int handle);
 extern int wgGetSocketV6(int handle);
 extern char *wgGetConfig(int handle);
 extern char *wgVersion();
-extern int wgTurnProxyStart(const char *peer_addr, const char *vklink, const char *mode, int n, int udp, const char *listen_addr, const char *turn_ip, int turn_port, const char *peer_type, int streams_per_cred, int watchdog_timeout, long long network_handle);
+extern int wgTurnProxyStart(const char *peer_addr, const char *vklink, const char *mode, int n, int udp, const char *listen_addr, const char *turn_ip, int turn_port, const char *peer_type, int streams_per_cred, int watchdog_timeout, int use_wrap, const char *wrap_key_hex, long long network_handle);
 extern void wgTurnProxyStop();
 extern void wgNotifyNetworkChange();
 extern const char* getNetworkDnsServers(long long network_handle);
@@ -292,7 +292,7 @@ JNIEXPORT jstring JNICALL Java_com_wireguard_android_backend_GoBackend_wgVersion
 	return ret;
 }
 
-JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProxyStart(JNIEnv *env, jclass c, jstring peer_addr, jstring vklink, jstring mode, jint n, jint useUdp, jstring listen_addr, jstring turn_ip, jint turn_port, jstring peer_type, jint streams_per_cred, jint watchdog_timeout, jlong network_handle)
+JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProxyStart(JNIEnv *env, jclass c, jstring peer_addr, jstring vklink, jstring mode, jint n, jint useUdp, jstring listen_addr, jstring turn_ip, jint turn_port, jstring peer_type, jint streams_per_cred, jint watchdog_timeout, jint use_wrap, jstring wrap_key_hex, jlong network_handle)
 {
 	const char *peer_addr_jni = (*env)->GetStringUTFChars(env, peer_addr, 0);
 	const char *vklink_jni = (*env)->GetStringUTFChars(env, vklink, 0);
@@ -300,6 +300,7 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	const char *listen_addr_jni = (*env)->GetStringUTFChars(env, listen_addr, 0);
 	const char *turn_ip_jni = (*env)->GetStringUTFChars(env, turn_ip, 0);
 	const char *peer_type_jni = (*env)->GetStringUTFChars(env, peer_type, 0);
+	const char *wrap_key_hex_jni = (*env)->GetStringUTFChars(env, wrap_key_hex, 0);
 
 	// Duplicate strings to avoid MTE issues with JNI-tagged pointers during Go execution
 	char *peer_addr_str = peer_addr_jni ? strdup(peer_addr_jni) : NULL;
@@ -308,10 +309,11 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	char *listen_addr_str = listen_addr_jni ? strdup(listen_addr_jni) : NULL;
 	char *turn_ip_str = turn_ip_jni ? strdup(turn_ip_jni) : NULL;
 	char *peer_type_str = peer_type_jni ? strdup(peer_type_jni) : NULL;
+	char *wrap_key_hex_str = wrap_key_hex_jni ? strdup(wrap_key_hex_jni) : NULL;
 
 	update_current_network(env, network_handle);
 
-	int ret = wgTurnProxyStart(peer_addr_str, vklink_str, mode_str, (int)n, (int)useUdp, listen_addr_str, turn_ip_str, (int)turn_port, peer_type_str, (int)streams_per_cred, (int)watchdog_timeout, (long long)network_handle);
+	int ret = wgTurnProxyStart(peer_addr_str, vklink_str, mode_str, (int)n, (int)useUdp, listen_addr_str, turn_ip_str, (int)turn_port, peer_type_str, (int)streams_per_cred, (int)watchdog_timeout, (int)use_wrap, wrap_key_hex_str, (long long)network_handle);
 
 	(*env)->ReleaseStringUTFChars(env, peer_addr, peer_addr_jni);
 	(*env)->ReleaseStringUTFChars(env, vklink, vklink_jni);
@@ -319,6 +321,7 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	(*env)->ReleaseStringUTFChars(env, listen_addr, listen_addr_jni);
 	(*env)->ReleaseStringUTFChars(env, turn_ip, turn_ip_jni);
 	(*env)->ReleaseStringUTFChars(env, peer_type, peer_type_jni);
+	(*env)->ReleaseStringUTFChars(env, wrap_key_hex, wrap_key_hex_jni);
 
 	free(peer_addr_str);
 	free(vklink_str);
@@ -326,6 +329,7 @@ JNIEXPORT jint JNICALL Java_com_wireguard_android_backend_TurnBackend_wgTurnProx
 	free(listen_addr_str);
 	free(turn_ip_str);
 	free(peer_type_str);
+	free(wrap_key_hex_str);
 
 	return ret;
 }

--- a/tunnel/tools/libwg-go/turn-client.go
+++ b/tunnel/tools/libwg-go/turn-client.go
@@ -17,6 +17,7 @@ import "C"
 import (
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -69,45 +70,47 @@ var turnHTTPClient = &http.Client{
 			Timeout: 30 * time.Second,
 			Control: protectControl,
 		}).DialContext,
-		MaxIdleConns: 100,
+		MaxIdleConns:    100,
 		IdleConnTimeout: 90 * time.Second,
 	},
 }
 
 type stream struct {
-	ctx       context.Context
-	id        int
-	in        chan []byte
-	out       net.PacketConn
-	peer      atomic.Pointer[net.Addr] // Last seen addr from WireGuard
-	ready     atomic.Bool
-	sessionID []byte
-	cert      *tls.Certificate
+	ctx             context.Context
+	id              int
+	in              chan []byte
+	out             net.PacketConn
+	peer            atomic.Pointer[net.Addr] // Last seen addr from WireGuard
+	ready           atomic.Bool
+	sessionID       []byte
+	cert            *tls.Certificate
 	watchdogTimeout int
+	wrapKey         []byte
 }
 
-const iPacketBuffMaxSize = 2048;
+const iPacketBuffMaxSize = 2048
 
 var packetPool = sync.Pool{
-    New: func() interface{} {
-        return make([]byte, iPacketBuffMaxSize)
-    },
+	New: func() interface{} {
+		return make([]byte, iPacketBuffMaxSize)
+	},
 }
 
 // Metrics for diagnostics
 var (
-	dtlsTxDropCount   atomic.Uint64      // Drops in DTLS TX goroutine
-	dtlsRxErrorCount  atomic.Uint64      // Errors in DTLS RX goroutine
-	relayTxErrorCount atomic.Uint64      // Errors in relay TX
-	relayRxErrorCount atomic.Uint64      // Errors in relay RX
-	noDtlsTxDropCount atomic.Uint64      // Drops in NoDTLS TX
-	noDtlsRxErrorCount atomic.Uint64     // Errors in NoDTLS RX
+	dtlsTxDropCount    atomic.Uint64 // Drops in DTLS TX goroutine
+	dtlsRxErrorCount   atomic.Uint64 // Errors in DTLS RX goroutine
+	relayTxErrorCount  atomic.Uint64 // Errors in relay TX
+	relayRxErrorCount  atomic.Uint64 // Errors in relay RX
+	noDtlsTxDropCount  atomic.Uint64 // Drops in NoDTLS TX
+	noDtlsRxErrorCount atomic.Uint64 // Errors in NoDTLS RX
 )
 
 func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- struct{}, turnIp string, turnPort int, peerType string) {
 	for {
 		select {
-		case <-s.ctx.Done(): return
+		case <-s.ctx.Done():
+			return
 		default:
 		}
 
@@ -120,7 +123,9 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 				return fmt.Errorf("credentials function not initialized")
 			}
 			user, pass, addr, err := globalGetCreds(sCtx, link, s.id)
-			if err != nil { return fmt.Errorf("TURN creds failed: %w", err) }
+			if err != nil {
+				return fmt.Errorf("TURN creds failed: %w", err)
+			}
 
 			// Override TURN address if provided
 			if turnIp != "" {
@@ -148,12 +153,16 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 			var turnConn net.PacketConn
 			if udp {
 				c, err := dialer.DialContext(sCtx, "udp", addr)
-				if err != nil { return fmt.Errorf("TURN UDP dial failed: %w", err) }
+				if err != nil {
+					return fmt.Errorf("TURN UDP dial failed: %w", err)
+				}
 				defer c.Close()
 				turnConn = &connectedUDPConn{c.(*net.UDPConn)}
 			} else {
 				c, err := dialer.DialContext(sCtx, "tcp", addr)
-				if err != nil { return fmt.Errorf("TURN TCP dial failed: %w", err) }
+				if err != nil {
+					return fmt.Errorf("TURN TCP dial failed: %w", err)
+				}
 				defer c.Close()
 				turnConn = turn.NewSTUNConn(c)
 			}
@@ -162,7 +171,9 @@ func (s *stream) run(link string, peer *net.UDPAddr, udp bool, okchan chan<- str
 				STUNServerAddr: addr, TURNServerAddr: addr, Username: user, Password: pass,
 				Conn: turnConn, LoggerFactory: logging.NewDefaultLoggerFactory(),
 			})
-			if err != nil { return fmt.Errorf("TURN client creation failed: %w", err) }
+			if err != nil {
+				return fmt.Errorf("TURN client creation failed: %w", err)
+			}
 			defer client.Close()
 			if err := client.Listen(); err != nil {
 				// Check if this is an authentication error (stale credentials)
@@ -218,15 +229,17 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 
 	// WireGuard backend (s.in channel) -> TURN -> WireGuard server (TX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		for {
 			select {
-			case <-sCtx.Done(): return
+			case <-sCtx.Done():
+				return
 			case b := <-s.in:
-                _, err := relayConn.WriteTo(b, peer)
-                packetPool.Put(b[:cap(b)])
+				_, err := relayConn.WriteTo(b, peer)
+				packetPool.Put(b[:cap(b)])
 
-                if err != nil {
+				if err != nil {
 					noDtlsTxDropCount.Add(1)
 					turnLog("[STREAM %d] TX error: %v", s.id, err)
 					return
@@ -237,7 +250,8 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 
 	// WireGuard server -> TURN -> WireGuard backend (s.out socket) (RX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
 			n, from, err := relayConn.ReadFrom(buf)
@@ -262,7 +276,10 @@ func (s *stream) runNoDTLS(ctx context.Context, relayConn net.PacketConn, peer *
 	}()
 
 	s.ready.Store(true)
-	select { case okchan <- struct{}{}: default: }
+	select {
+	case okchan <- struct{}{}:
+	default:
+	}
 
 	wg.Wait()
 	return nil
@@ -274,6 +291,19 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 	defer sCancel()
 
 	var dtlsConn *dtls.Conn
+	var wrapTX, wrapRX *wrapConn
+	if len(s.wrapKey) == wrapKeyLen {
+		var wrapErr error
+		wrapTX, wrapErr = newWrapConn(s.wrapKey, false)
+		if wrapErr != nil {
+			return fmt.Errorf("WRAP tx init failed: %w", wrapErr)
+		}
+		wrapRX, wrapErr = newWrapConn(s.wrapKey, false)
+		if wrapErr != nil {
+			return fmt.Errorf("WRAP rx init failed: %w", wrapErr)
+		}
+		turnLog("[STREAM %d] WRAP enabled", s.id)
+	}
 
 	c1, c2 := connutil.AsyncPacketPipe()
 	defer c1.Close()
@@ -281,11 +311,13 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	dtlsConn, err := dtls.Client(c1, peer, &dtls.Config{
 		Certificates: []tls.Certificate{*s.cert}, InsecureSkipVerify: true,
-		ExtendedMasterSecret: dtls.RequireExtendedMasterSecret,
-		CipherSuites: []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+		ExtendedMasterSecret:  dtls.RequireExtendedMasterSecret,
+		CipherSuites:          []dtls.CipherSuiteID{dtls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 		ConnectionIDGenerator: dtls.OnlySendCIDGenerator(),
 	})
-	if err != nil { return fmt.Errorf("DTLS client creation failed: %w", err) }
+	if err != nil {
+		return fmt.Errorf("DTLS client creation failed: %w", err)
+	}
 	defer dtlsConn.Close()
 
 	wg := sync.WaitGroup{}
@@ -299,12 +331,26 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	// DTLS <-> Relay (via Pipe) - MUST start before handshake
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
 			n, _, err := c2.ReadFrom(buf)
-			if err != nil { return }
-			if _, err := relayConn.WriteTo(buf[:n], peer); err != nil {
+			if err != nil {
+				return
+			}
+			out := buf[:n]
+			if wrapTX != nil {
+				wrapped := make([]byte, wrapMaxWire(n))
+				m, wrapErr := wrapTX.wrapInto(wrapped, out)
+				if wrapErr != nil {
+					relayTxErrorCount.Add(1)
+					turnLog("[STREAM %d] WRAP TX error: %v", s.id, wrapErr)
+					return
+				}
+				out = wrapped[:m]
+			}
+			if _, err := relayConn.WriteTo(out, peer); err != nil {
 				relayTxErrorCount.Add(1)
 				turnLog("[STREAM %d] Relay TX error: %v", s.id, err)
 				return
@@ -313,8 +359,13 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 	}()
 
 	go func() {
-		defer wg.Done(); defer sCancel()
-		buf := make([]byte, iPacketBuffMaxSize)
+		defer wg.Done()
+		defer sCancel()
+		readBufSize := iPacketBuffMaxSize
+		if wrapRX != nil {
+			readBufSize = wrapMaxWire(iPacketBuffMaxSize)
+		}
+		buf := make([]byte, readBufSize)
 		for {
 			n, from, err := relayConn.ReadFrom(buf)
 			if err != nil {
@@ -323,7 +374,18 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 				return
 			}
 			if from.String() == peer.String() {
-				if _, err := c2.WriteTo(buf[:n], peer); err != nil {
+				in := buf[:n]
+				if wrapRX != nil {
+					plain := make([]byte, iPacketBuffMaxSize)
+					m, wrapErr := wrapRX.unwrapPacket(in, plain)
+					if wrapErr != nil {
+						relayRxErrorCount.Add(1)
+						turnLog("[STREAM %d] WRAP RX error: %v", s.id, wrapErr)
+						continue
+					}
+					in = plain[:m]
+				}
+				if _, err := c2.WriteTo(in, peer); err != nil {
 					relayTxErrorCount.Add(1)
 					turnLog("[STREAM %d] Relay RX->Pipe error: %v", s.id, err)
 					return
@@ -339,7 +401,8 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 		defer ticker.Stop()
 		for {
 			select {
-			case <-sCtx.Done(): return
+			case <-sCtx.Done():
+				return
 			case <-ticker.C:
 				deadline := time.Now().Add(30 * time.Second)
 				relayConn.SetDeadline(deadline)
@@ -376,7 +439,10 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 	}
 
 	s.ready.Store(true)
-	select { case okchan <- struct{}{}: default: }
+	select {
+	case okchan <- struct{}{}:
+	default:
+	}
 
 	var lastRx atomic.Int64
 	lastRx.Store(time.Now().Unix())
@@ -385,15 +451,17 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	// WireGuard -> DTLS (TX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		for {
 			select {
-			case <-sCtx.Done(): return
+			case <-sCtx.Done():
+				return
 			case b := <-s.in:
 
 				// Watchdog (only active if watchdogTimeout > 0)
 				if s.watchdogTimeout > 0 && time.Since(time.Unix(lastRx.Load(), 0)) > time.Duration(s.watchdogTimeout)*time.Second {
-				    packetPool.Put(b[:cap(b)])
+					packetPool.Put(b[:cap(b)])
 					dtlsTxDropCount.Add(1)
 					turnLog("[STREAM %d] TX watchdog timeout (%ds)", s.id, s.watchdogTimeout)
 					return
@@ -413,7 +481,8 @@ func (s *stream) runDTLS(ctx context.Context, relayConn net.PacketConn, peer *ne
 
 	// DTLS -> WireGuard (RX)
 	go func() {
-		defer wg.Done(); defer sCancel()
+		defer wg.Done()
+		defer sCancel()
 		buf := make([]byte, iPacketBuffMaxSize)
 		for {
 			n, err := dtlsConn.Read(buf)
@@ -442,8 +511,9 @@ var turnMutex sync.Mutex
 
 // Global credentials function for mode selection (set by wgTurnProxyStart)
 var globalGetCreds getCredsFunc
+
 //export wgTurnProxyStart
-func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int, udp C.int, listenAddrC *C.char, turnIpC *C.char, turnPortC C.int, peerTypeC *C.char, streamsPerCredC C.int, watchdogTimeoutC C.int, networkHandleC C.longlong) int32 {
+func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int, udp C.int, listenAddrC *C.char, turnIpC *C.char, turnPortC C.int, peerTypeC *C.char, streamsPerCredC C.int, watchdogTimeoutC C.int, useWrapC C.int, wrapKeyHexC *C.char, networkHandleC C.longlong) int32 {
 	// Force initialization of resolver and HTTP client with current environment
 	wgNotifyNetworkChange()
 
@@ -466,11 +536,29 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 	peerType := C.GoString(peerTypeC)
 	streamsPerCred = int(streamsPerCredC)
 	watchdogTimeout := int(watchdogTimeoutC)
+	useWrap := int(useWrapC) != 0
+	wrapKeyHex := strings.TrimSpace(C.GoString(wrapKeyHexC))
 	networkHandle := int64(networkHandleC)
+	var wrapKey []byte
+	if useWrap {
+		if udp != 0 || peerType == "wireguard" {
+			turnLog("[PROXY] WRAP requires DTLS proxy_v1/proxy_v2 mode")
+			return -1
+		}
+		var err error
+		wrapKey, err = hex.DecodeString(wrapKeyHex)
+		if err != nil || len(wrapKey) != wrapKeyLen {
+			turnLog("[PROXY] Invalid WRAP key: must be 64 hex characters")
+			return -1
+		}
+		turnLog("[PROXY] WRAP mode enabled")
+	}
 
-	turnLog("[PROXY] Hub starting on %s (streams=%d, mode=%s, peerType=%s, streamsPerCred=%d, watchdogTimeout=%d, networkHandle=%d)", listenAddr, int(n), mode, peerType, streamsPerCred, watchdogTimeout, networkHandle)
+	turnLog("[PROXY] Hub starting on %s (streams=%d, mode=%s, peerType=%s, streamsPerCred=%d, watchdogTimeout=%d, wrap=%t, networkHandle=%d)", listenAddr, int(n), mode, peerType, streamsPerCred, watchdogTimeout, useWrap, networkHandle)
 	turnMutex.Lock()
-	if currentTurnCancel != nil { currentTurnCancel() }
+	if currentTurnCancel != nil {
+		currentTurnCancel()
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	currentTurnCancel = cancel
 	turnMutex.Unlock()
@@ -485,7 +573,9 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 		turnLog("[PROXY] Using VK Link credential mode")
 		parts := strings.Split(vklink, "join/")
 		link := parts[len(parts)-1]
-		if idx := strings.IndexAny(link, "/?#"); idx != -1 { link = link[:idx] }
+		if idx := strings.IndexAny(link, "/?#"); idx != -1 {
+			link = link[:idx]
+		}
 		globalGetCreds = func(ctx context.Context, lk string, streamID int) (string, string, string, error) {
 			return getCredsCached(ctx, lk, streamID, fetchVkCreds)
 		}
@@ -501,20 +591,28 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 			if err != nil {
 				turnLog("[DNS] Warning: failed to resolve peer: %v, using original", err)
 				peer, err = net.ResolveUDPAddr("udp", peerAddr)
-				if err != nil { return -1 }
+				if err != nil {
+					return -1
+				}
 			} else {
 				peerAddr = net.JoinHostPort(resolvedIP, port)
 				//turnLog("[DNS] Resolved peer %s -> %s", host, resolvedIP)
 				peer, err = net.ResolveUDPAddr("udp", peerAddr)
-				if err != nil { return -1 }
+				if err != nil {
+					return -1
+				}
 			}
 		} else {
 			peer, err = net.ResolveUDPAddr("udp", peerAddr)
-			if err != nil { return -1 }
+			if err != nil {
+				return -1
+			}
 		}
 	} else {
 		peer, err = net.ResolveUDPAddr("udp", peerAddr)
-		if err != nil { return -1 }
+		if err != nil {
+			return -1
+		}
 	}
 
 	// Determine link for VK mode (for WB mode, link is just "wb")
@@ -524,11 +622,15 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 	} else {
 		parts := strings.Split(vklink, "join/")
 		link = parts[len(parts)-1]
-		if idx := strings.IndexAny(link, "/?#"); idx != -1 { link = link[:idx] }
+		if idx := strings.IndexAny(link, "/?#"); idx != -1 {
+			link = link[:idx]
+		}
 	}
 
 	lc, err := net.ListenPacket("udp", listenAddr)
-	if err != nil { return -1 }
+	if err != nil {
+		return -1
+	}
 	context.AfterFunc(ctx, func() { lc.Close() })
 
 	// Generate fresh Session ID for every run to avoid server-side conflicts
@@ -545,7 +647,7 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 	ok := make(chan struct{}, int(n))
 	streams := make([]*stream, int(n))
 	for i := 0; i < int(n); i++ {
-		streams[i] = &stream{ctx: ctx, id: i, in: make(chan []byte, 512), out: lc, sessionID: sessionID, cert: &cert, watchdogTimeout: watchdogTimeout}
+		streams[i] = &stream{ctx: ctx, id: i, in: make(chan []byte, 512), out: lc, sessionID: sessionID, cert: &cert, watchdogTimeout: watchdogTimeout, wrapKey: wrapKey}
 		go streams[i].run(link, peer, udp != 0, ok, turnIp, turnPort, peerType)
 		time.Sleep(200 * time.Millisecond)
 	}
@@ -555,29 +657,29 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 		var lastUsed int = 0
 
 		for {
-		    b := packetPool.Get().([]byte)[:iPacketBuffMaxSize]
+			b := packetPool.Get().([]byte)[:iPacketBuffMaxSize]
 			nRead, addr, err := lc.ReadFrom(b)
 			if err != nil {
-			    packetPool.Put(b[:cap(b)])
-			    return
+				packetPool.Put(b[:cap(b)])
+				return
 			}
 
 			// Round-Robin selection
 			lastUsed = (lastUsed + 1) % nStreams
 
-            var s *stream
-            for i := 0; i < nStreams; i++ {
-            	st := streams[(lastUsed+i)%nStreams]
-            	if st.ready.Load() {
-            		s = st
-            		break
-            	}
-            }
+			var s *stream
+			for i := 0; i < nStreams; i++ {
+				st := streams[(lastUsed+i)%nStreams]
+				if st.ready.Load() {
+					s = st
+					break
+				}
+			}
 
-            if s == nil {
-                packetPool.Put(b[:cap(b)])
-            	continue
-            }
+			if s == nil {
+				packetPool.Put(b[:cap(b)])
+				continue
+			}
 
 			returnAddr := addr
 			s.peer.Store(&returnAddr)
@@ -586,7 +688,7 @@ func wgTurnProxyStart(peerAddrC *C.char, vklinkC *C.char, modeC *C.char, n C.int
 			case s.in <- b[:nRead]:
 				// Packet queued successfully
 			default:
-                packetPool.Put(b[:cap(b)])
+				packetPool.Put(b[:cap(b)])
 			}
 		}
 	}()
@@ -612,5 +714,6 @@ func wgTurnProxyStop() {
 	}
 }
 
-type connectedUDPConn struct { *net.UDPConn }
+type connectedUDPConn struct{ *net.UDPConn }
+
 func (c *connectedUDPConn) WriteTo(p []byte, _ net.Addr) (int, error) { return c.Write(p) }

--- a/tunnel/tools/libwg-go/vk_captcha.go
+++ b/tunnel/tools/libwg-go/vk_captcha.go
@@ -44,7 +44,6 @@ type VkCaptchaError struct {
 }
 
 func ParseVkCaptchaError(errData map[string]interface{}) *VkCaptchaError {
-	// Extract error_code
 	codeFloat, ok := errData["error_code"].(float64)
 	if !ok {
 		turnLog("missing error_code in captcha error data")
@@ -52,57 +51,40 @@ func ParseVkCaptchaError(errData map[string]interface{}) *VkCaptchaError {
 	}
 	code := int(codeFloat)
 
-	// Extract redirect_uri
-	RedirectURI, ok := errData["redirect_uri"].(string)
+	redirectURI, ok := errData["redirect_uri"].(string)
 	if !ok {
 		turnLog("missing redirect_uri in captcha error data")
 		return nil
 	}
 
-	// Extract captcha_sid
-	captchaSid, ok := errData["captcha_sid"].(string)
-	if !ok {
-		// try numeric
-		if sidNum, ok2 := errData["captcha_sid"].(float64); ok2 {
-			captchaSid = fmt.Sprintf("%.0f", sidNum)
-		} else {
-			turnLog("missing captcha_sid in captcha error data")
-			return nil
-		}
-	}
-
-	// Extract captcha_img
-	captchaImg, ok := errData["captcha_img"].(string)
-	if !ok {
-		turnLog("missing captcha_img in captcha error data")
-		return nil
-	}
-
-	// Extract error_msg
-	errorMsg, ok := errData["error_msg"].(string)
-	if !ok {
-		turnLog("missing error_msg in captcha error data")
-		return nil
-	}
-
-	// Extract session token if redirect_uri present
 	var sessionToken string
-	if RedirectURI != "" {
-		if parsed, err := neturl.Parse(RedirectURI); err == nil {
-			sessionToken = parsed.Query().Get("session_token")
-		} else {
-			turnLog("failed to parse redirect_uri: %v", err)
-			return nil
-		}
+	if parsed, err := neturl.Parse(redirectURI); err == nil {
+		sessionToken = parsed.Query().Get("session_token")
+	} else {
+		turnLog("failed to parse redirect_uri: %v", err)
+		return nil
 	}
 
-	// Extract is_sound_captcha_available
+	if code == 14 && sessionToken == "" {
+		turnLog("missing session_token in captcha redirect_uri")
+		return nil
+	}
+
+	var captchaSid string
+	if sid, ok := errData["captcha_sid"].(string); ok {
+		captchaSid = sid
+	} else if sidNum, ok := errData["captcha_sid"].(float64); ok {
+		captchaSid = fmt.Sprintf("%.0f", sidNum)
+	}
+
+	captchaImg, _ := errData["captcha_img"].(string)
+	errorMsg, _ := errData["error_msg"].(string)
+
 	isSound, ok := errData["is_sound_captcha_available"].(bool)
 	if !ok {
 		isSound = false
 	}
 
-	// Extract captcha_ts
 	var captchaTs string
 	if tsFloat, ok := errData["captcha_ts"].(float64); ok {
 		captchaTs = fmt.Sprintf("%.0f", tsFloat)
@@ -110,7 +92,6 @@ func ParseVkCaptchaError(errData map[string]interface{}) *VkCaptchaError {
 		captchaTs = tsStr
 	}
 
-	// Extract captcha_attempt
 	var captchaAttempt string
 	if attFloat, ok := errData["captcha_attempt"].(float64); ok {
 		captchaAttempt = fmt.Sprintf("%.0f", attFloat)
@@ -118,13 +99,12 @@ func ParseVkCaptchaError(errData map[string]interface{}) *VkCaptchaError {
 		captchaAttempt = attStr
 	}
 
-	// Build VkCaptchaError
 	return &VkCaptchaError{
 		ErrorCode:               code,
 		ErrorMsg:                errorMsg,
 		CaptchaSid:              captchaSid,
 		CaptchaImg:              captchaImg,
-		RedirectURI:             RedirectURI,
+		RedirectURI:             redirectURI,
 		IsSoundCaptchaAvailable: isSound,
 		SessionToken:            sessionToken,
 		CaptchaTs:               captchaTs,

--- a/tunnel/tools/libwg-go/vk_captcha_test.go
+++ b/tunnel/tools/libwg-go/vk_captcha_test.go
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright © 2026 WireGuard LLC. All Rights Reserved.
+ */
+
+package main
+
+import "testing"
+
+func TestParseVkCaptchaErrorAcceptsNotRobotRedirectOnly(t *testing.T) {
+	captchaErr := ParseVkCaptchaError(map[string]interface{}{
+		"error_code":         float64(14),
+		"error_msg":          "Captcha need",
+		"is_enabled_captcha": true,
+		"redirect_uri":       "https://id.vk.ru/not_robot_captcha?domain=vk.com&session_token=test-token&variant=popup&blank=1",
+	})
+
+	if captchaErr == nil {
+		t.Fatal("expected captcha error")
+	}
+	if !captchaErr.IsCaptchaError() {
+		t.Fatal("expected IsCaptchaError to be true")
+	}
+	if captchaErr.SessionToken != "test-token" {
+		t.Fatalf("unexpected session token: %q", captchaErr.SessionToken)
+	}
+	if captchaErr.CaptchaSid != "" {
+		t.Fatalf("expected empty legacy captcha sid, got %q", captchaErr.CaptchaSid)
+	}
+	if captchaErr.CaptchaImg != "" {
+		t.Fatalf("expected empty legacy captcha image, got %q", captchaErr.CaptchaImg)
+	}
+}
+
+func TestParseVkCaptchaErrorKeepsLegacyFields(t *testing.T) {
+	captchaErr := ParseVkCaptchaError(map[string]interface{}{
+		"error_code":                 float64(14),
+		"error_msg":                  "Captcha need",
+		"redirect_uri":               "https://id.vk.ru/not_robot_captcha?session_token=test-token",
+		"captcha_sid":                float64(12345),
+		"captcha_img":                "https://example.com/captcha.jpg",
+		"is_sound_captcha_available": true,
+		"captcha_ts":                 float64(67890),
+		"captcha_attempt":            "2",
+	})
+
+	if captchaErr == nil {
+		t.Fatal("expected captcha error")
+	}
+	if captchaErr.CaptchaSid != "12345" {
+		t.Fatalf("unexpected captcha sid: %q", captchaErr.CaptchaSid)
+	}
+	if captchaErr.CaptchaImg != "https://example.com/captcha.jpg" {
+		t.Fatalf("unexpected captcha image: %q", captchaErr.CaptchaImg)
+	}
+	if !captchaErr.IsSoundCaptchaAvailable {
+		t.Fatal("expected sound captcha flag")
+	}
+	if captchaErr.CaptchaTs != "67890" {
+		t.Fatalf("unexpected captcha_ts: %q", captchaErr.CaptchaTs)
+	}
+	if captchaErr.CaptchaAttempt != "2" {
+		t.Fatalf("unexpected captcha_attempt: %q", captchaErr.CaptchaAttempt)
+	}
+}

--- a/tunnel/tools/libwg-go/wrap.go
+++ b/tunnel/tools/libwg-go/wrap.go
@@ -1,0 +1,120 @@
+/* SPDX-License-Identifier: MIT */
+
+package main
+
+import (
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	wrapKeyLen     = 32
+	wrapRTPHdrLen  = 12
+	wrapNonceLen   = 12
+	wrapTagLen     = 16
+	wrapHeaderLen  = wrapRTPHdrLen + wrapNonceLen
+	wrapOverhead   = wrapHeaderLen + wrapTagLen
+	wrapRTPVersion = 0x80
+	wrapRTPPT      = 0x6F
+	wrapTSStep     = 960
+)
+
+type wrapConn struct {
+	aead      cipher.AEAD
+	sessionID [4]byte
+	ssrc      [4]byte
+	counter   atomic.Uint64
+	seq       atomic.Uint32
+	timestamp atomic.Uint32
+}
+
+func newWrapConn(key []byte, isServer bool) (*wrapConn, error) {
+	if len(key) != wrapKeyLen {
+		return nil, fmt.Errorf("wrap: key must be %d bytes (got %d)", wrapKeyLen, len(key))
+	}
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, fmt.Errorf("wrap: aead init: %w", err)
+	}
+	w := &wrapConn{aead: aead}
+
+	var rnd [16]byte
+	if _, err := rand.Read(rnd[:]); err != nil {
+		return nil, fmt.Errorf("wrap: rand init: %w", err)
+	}
+	copy(w.sessionID[:], rnd[0:4])
+	copy(w.ssrc[:], rnd[4:8])
+	if isServer {
+		w.sessionID[0] |= 0x80
+		w.ssrc[0] |= 0x80
+	} else {
+		w.sessionID[0] &^= 0x80
+		w.ssrc[0] &^= 0x80
+	}
+	w.seq.Store(uint32(binary.BigEndian.Uint16(rnd[8:10])))
+	w.timestamp.Store(binary.BigEndian.Uint32(rnd[10:14]))
+
+	var cb [8]byte
+	if _, err := rand.Read(cb[:]); err != nil {
+		return nil, fmt.Errorf("wrap: counter rand: %w", err)
+	}
+	w.counter.Store(binary.BigEndian.Uint64(cb[:]))
+	return w, nil
+}
+
+func wrapMaxWire(payloadLen int) int {
+	return wrapOverhead + payloadLen
+}
+
+func (w *wrapConn) wrapInto(dst, payload []byte) (int, error) {
+	wireLen := wrapOverhead + len(payload)
+	if len(dst) < wireLen {
+		return 0, errors.New("wrap: dst buffer too small")
+	}
+
+	dst[0] = wrapRTPVersion
+	dst[1] = wrapRTPPT
+	seq := uint16(w.seq.Add(1) - 1)
+	binary.BigEndian.PutUint16(dst[2:4], seq)
+	ts := w.timestamp.Add(wrapTSStep) - wrapTSStep
+	binary.BigEndian.PutUint32(dst[4:8], ts)
+	copy(dst[8:12], w.ssrc[:])
+
+	noncePos := wrapRTPHdrLen
+	copy(dst[noncePos:noncePos+4], w.sessionID[:])
+	ctr := w.counter.Add(1) - 1
+	binary.BigEndian.PutUint64(dst[noncePos+4:noncePos+wrapNonceLen], ctr)
+
+	nonce := dst[noncePos : noncePos+wrapNonceLen]
+	aad := dst[:wrapHeaderLen]
+	ctPos := wrapHeaderLen
+	copy(dst[ctPos:], payload)
+	w.aead.Seal(dst[ctPos:ctPos], nonce, dst[ctPos:ctPos+len(payload)], aad)
+
+	return wireLen, nil
+}
+
+func (w *wrapConn) unwrapPacket(wire, dst []byte) (int, error) {
+	if len(wire) < wrapOverhead {
+		return 0, errors.New("wrap: packet too short")
+	}
+	nonce := wire[wrapRTPHdrLen : wrapRTPHdrLen+wrapNonceLen]
+	aad := wire[:wrapHeaderLen]
+	ct := wire[wrapHeaderLen:]
+
+	plain, err := w.aead.Open(ct[:0], nonce, ct, aad)
+	if err != nil {
+		return 0, fmt.Errorf("wrap: AEAD open: %w", err)
+	}
+	if len(plain) > len(dst) {
+		return 0, errors.New("wrap: dst buffer too small")
+	}
+	copy(dst[:len(plain)], plain)
+	return len(plain), nil
+}

--- a/ui/src/main/java/com/wireguard/android/turn/TurnProxyManager.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnProxyManager.kt
@@ -224,6 +224,8 @@ class TurnProxyManager(private val context: Context) {
                     settings.peerType,
                     settings.streamsPerCred,
                     settings.watchdogTimeout,
+                    if (settings.useWrap) 1 else 0,
+                    settings.wrapKeyHex,
                     networkHandle
                 )
 

--- a/ui/src/main/java/com/wireguard/android/turn/TurnSettings.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnSettings.kt
@@ -22,6 +22,8 @@ data class TurnSettings(
     val peerType: String = "proxy_v2",  // "proxy_v2", "proxy_v1", "wireguard"
     val streamsPerCred: Int = 4,
     val watchdogTimeout: Int = 0,
+    val useWrap: Boolean = false,
+    val wrapKeyHex: String = "",
 ) {
     fun toComments(): List<String> {
         val lines = mutableListOf(
@@ -40,6 +42,10 @@ data class TurnSettings(
         if (turnIp.isNotBlank()) lines.add("#@wgt:TurnIP = $turnIp")
         if (turnPort > 0) lines.add("#@wgt:TurnPort = $turnPort")
         if (watchdogTimeout > 0) lines.add("#@wgt:WatchdogTimeout = $watchdogTimeout")
+        if (useWrap) {
+            lines.add("#@wgt:UseWrap = true")
+            lines.add("#@wgt:WrapKeyHex = $wrapKeyHex")
+        }
         return lines
     }
 
@@ -57,6 +63,8 @@ data class TurnSettings(
             var peerType: String? = null  // null means not set, will be determined from noDtls
             var streamsPerCred = 4
             var watchdogTimeout = 0
+            var useWrap = false
+            var wrapKeyHex = ""
             var noDtlsLegacy = false
             var foundAny = false
 
@@ -82,6 +90,8 @@ data class TurnSettings(
                     "nodtls" -> noDtlsLegacy = value.toBoolean()  // legacy, for backward compatibility
                     "peertype" -> peerType = value
                     "streamspercred" -> streamsPerCred = value.toIntOrNull() ?: 4
+                    "usewrap" -> useWrap = value.toBoolean()
+                    "wrapkeyhex" -> wrapKeyHex = value
                 }
             }
 
@@ -90,7 +100,7 @@ data class TurnSettings(
                 peerType = if (noDtlsLegacy) "wireguard" else "proxy_v2"
             }
 
-            return if (foundAny) TurnSettings(enabled, peer, vkLink, mode, streams, useUdp, localPort, turnIp, turnPort, peerType, streamsPerCred, watchdogTimeout) else null
+            return if (foundAny) TurnSettings(enabled, peer, vkLink, mode, streams, useUdp, localPort, turnIp, turnPort, peerType, streamsPerCred, watchdogTimeout, useWrap, wrapKeyHex) else null
         }
 
         fun validate(settings: TurnSettings): TurnSettings {
@@ -111,6 +121,11 @@ data class TurnSettings(
 
             if (settings.watchdogTimeout > 0) {
                 require(settings.watchdogTimeout >= 5) { "Watchdog timeout must be at least 5 seconds or 0 to disable" }
+            }
+            if (settings.useWrap) {
+                require(!settings.useUdp) { "WRAP requires DTLS/TCP mode; disable UDP" }
+                require(settings.peerType != "wireguard") { "WRAP requires proxy_v1 or proxy_v2" }
+                require(settings.wrapKeyHex.matches(Regex("^[0-9a-fA-F]{64}$"))) { "WRAP key must be 64 hex characters" }
             }
 
             // Very small sanity check for host:port format; full validation is done later when applying.

--- a/ui/src/main/java/com/wireguard/android/turn/TurnSettingsStore.kt
+++ b/ui/src/main/java/com/wireguard/android/turn/TurnSettingsStore.kt
@@ -47,6 +47,9 @@ class TurnSettingsStore(private val context: Context) {
                     turnPort = json.optInt("turnPort", 0),
                     peerType = json.optString("peerType", peerTypeDefault),
                     streamsPerCred = json.optInt("streamsPerCred", 4),
+                    watchdogTimeout = json.optInt("watchdogTimeout", 0),
+                    useWrap = json.optBoolean("useWrap", false),
+                    wrapKeyHex = json.optString("wrapKeyHex", ""),
                 )
                 settings
             }
@@ -77,6 +80,9 @@ class TurnSettingsStore(private val context: Context) {
             .put("turnPort", settings.turnPort)
             .put("peerType", settings.peerType)
             .put("streamsPerCred", settings.streamsPerCred)
+            .put("watchdogTimeout", settings.watchdogTimeout)
+            .put("useWrap", settings.useWrap)
+            .put("wrapKeyHex", settings.wrapKeyHex)
 
         file.parentFile?.mkdirs()
         FileOutputStream(file, false).use { stream ->
@@ -107,4 +113,3 @@ class TurnSettingsStore(private val context: Context) {
         private const val TAG = "WireGuard/TurnSettingsStore"
     }
 }
-

--- a/ui/src/main/java/com/wireguard/android/viewmodel/TurnSettingsProxy.kt
+++ b/ui/src/main/java/com/wireguard/android/viewmodel/TurnSettingsProxy.kt
@@ -98,6 +98,20 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         }
 
     @get:Bindable
+    var useWrap: Boolean = false
+        set(value) {
+            field = value
+            notifyPropertyChanged(BR.useWrap)
+        }
+
+    @get:Bindable
+    var wrapKeyHex: String = ""
+        set(value) {
+            field = value
+            notifyPropertyChanged(BR.wrapKeyHex)
+        }
+
+    @get:Bindable
     var advancedExpanded: Boolean = false
         set(value) {
             field = value
@@ -117,6 +131,8 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         watchdogTimeout = parcel.readString() ?: ""
         peerType = parcel.readString() ?: "proxy_v2"
         streamsPerCred = parcel.readString() ?: ""
+        useWrap = parcel.readInt() != 0
+        wrapKeyHex = parcel.readString() ?: ""
         advancedExpanded = parcel.readInt() != 0
     }
 
@@ -136,6 +152,8 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
             watchdogTimeout = if (other.watchdogTimeout > 0) other.watchdogTimeout.toString() else ""
             peerType = other.peerType
             streamsPerCred = other.streamsPerCred.toString()
+            useWrap = other.useWrap
+            wrapKeyHex = other.wrapKeyHex
         }
     }
 
@@ -154,6 +172,8 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
         dest.writeString(watchdogTimeout)
         dest.writeString(peerType)
         dest.writeString(streamsPerCred)
+        dest.writeInt(if (useWrap) 1 else 0)
+        dest.writeString(wrapKeyHex)
         dest.writeInt(if (advancedExpanded) 1 else 0)
     }
 
@@ -185,6 +205,11 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
             if (parsedStreamsPerCred !in 1..16) {
                 throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, streamsPerCred)
             }
+            if (useWrap) {
+                if (useUdp || peerType == "wireguard" || !wrapKeyHex.matches(Regex("^[0-9a-fA-F]{64}$"))) {
+                    throw BadConfigException(BadConfigException.Section.INTERFACE, BadConfigException.Location.TOP_LEVEL, BadConfigException.Reason.INVALID_VALUE, wrapKeyHex)
+                }
+            }
 
             if (peer.isBlank()) {
                 throw BadConfigException(BadConfigException.Section.PEER, BadConfigException.Location.ENDPOINT, BadConfigException.Reason.MISSING_ATTRIBUTE, peer)
@@ -210,6 +235,8 @@ class TurnSettingsProxy : BaseObservable, Parcelable {
             peerType = peerType,
             streamsPerCred = parsedStreamsPerCred,
             watchdogTimeout = parsedWatchdogTimeout,
+            useWrap = useWrap,
+            wrapKeyHex = wrapKeyHex.trim(),
         )
         if (enabled) {
             TurnSettings.validate(settings)

--- a/ui/src/main/res/layout/tunnel_detail_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_detail_fragment.xml
@@ -400,7 +400,7 @@
                         android:id="@+id/turn_options_text"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text='@{String.format("UDP: %b, Streams: %d, Streams/Cred: %d", tunnel.turnSettings.useUdp, tunnel.turnSettings.streams, tunnel.turnSettings.streamsPerCred)}'
+                        android:text='@{String.format("UDP: %b, Streams: %d, Streams/Cred: %d, WRAP: %b", tunnel.turnSettings.useUdp, tunnel.turnSettings.streams, tunnel.turnSettings.streamsPerCred, tunnel.turnSettings.useWrap)}'
                         android:textAppearance="?attr/textAppearanceBodyLarge"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/turn_options_label"

--- a/ui/src/main/res/layout/tunnel_editor_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_editor_fragment.xml
@@ -573,6 +573,36 @@
                                     android:hint="@string/turn_streams_per_cred_hint"
                                     android:text="@={config.turn.streamsPerCred}" />
                             </com.google.android.material.textfield.TextInputLayout>
+
+                            <com.google.android.material.materialswitch.MaterialSwitch
+                                android:id="@+id/turn_wrap_switch"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_margin="4dp"
+                                android:checked="@={config.turn.useWrap}"
+                                android:enabled="@{config.turn.enabled}"
+                                android:text="@string/turn_use_wrap" />
+
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:id="@+id/turn_wrap_key_layout"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_margin="4dp"
+                                android:enabled="@{config.turn.enabled &amp;&amp; config.turn.useWrap}"
+                                android:hint="@string/turn_wrap_key"
+                                android:visibility="@{config.turn.useWrap ? android.view.View.VISIBLE : android.view.View.GONE}"
+                                app:expandedHintEnabled="false">
+
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/turn_wrap_key_text"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:enabled="@{config.turn.enabled &amp;&amp; config.turn.useWrap}"
+                                    android:hint="@string/turn_wrap_key_hint"
+                                    android:imeOptions="actionDone"
+                                    android:inputType="textNoSuggestions|textVisiblePassword"
+                                    android:text="@={config.turn.wrapKeyHex}" />
+                            </com.google.android.material.textfield.TextInputLayout>
                         </LinearLayout>
 
                     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -298,6 +298,9 @@
     <string name="turn_watchdog_timeout_hint">0=disabled, ≥5 sec</string>
     <string name="turn_streams_per_cred">Streams per credentials</string>
     <string name="turn_streams_per_cred_hint">1-16 (default 4)</string>
+    <string name="turn_use_wrap">Use WRAP</string>
+    <string name="turn_wrap_key">WRAP key</string>
+    <string name="turn_wrap_key_hint">64 hex chars</string>
     <string name="captcha_title">Verify You Are Human</string>
     <string name="captcha_loading">Loading captcha…</string>
     <string name="captcha_error">Failed to solve captcha. Please try again.</string>


### PR DESCRIPTION
## Summary

Adds TURN WRAP support to the Android client.

This lets Android import and run vk-turn-proxy profiles that use WRAP encryption over DTLS, matching the server-side `-wrap` / `-wrap-key` mode.

## Changes

- Added `UseWrap` and `WrapKeyHex` TURN config fields.
- Added import/export support via WireGuard config comments:
  - `#@wgt:UseWrap = true`
  - `#@wgt:WrapKeyHex = <64-hex-key>`
- Added Android UI controls for enabling WRAP and entering the WRAP key.
- Persisted WRAP settings in `TurnSettingsStore`.
- Passed WRAP settings through Kotlin → Java → JNI → Go.
- Implemented WRAP packet wrapping/unwrapping in the Go TURN client.
- Validated WRAP usage:
  - requires DTLS mode
  - rejects `wireguard`/no-DTLS mode
  - requires a 64-character hex key
- Bumped app version to `2.2.21`.
- Fixed release APK rename path in the release workflow.

## Testing

- Built successfully with GitHub Actions
- Generated and imported Android WRAP profiles
- Verified WRAP connection works against existing `vk-turn-proxy` WRAP server.